### PR TITLE
Cleanup eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,8 +11,5 @@
   "globals": {
     "Polymer": false,
     "Vaadin": false
-  },
-  "rules": {
-    "arrow-spacing": "error"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "wct"
   },
   "devDependencies": {
-    "eslint-config-vaadin": "github:vaadin/eslint-config-vaadin",
+    "eslint-config-vaadin": "^0.1.0",
     "eslint-plugin-html": "^1.7.0",
     "gemini": "^4.14.3",
     "gemini-polyserve": "^1.0.0",
@@ -32,7 +32,7 @@
     "gulp-stylelint": "^3.7.0",
     "lighthouse": "~1.2.2",
     "polyserve": "^0.15.0",
-    "stylelint-config-vaadin": "github:vaadin/stylelint-config-vaadin",
+    "stylelint-config-vaadin": "^0.1.0",
     "web-component-tester": "^5.0.0"
   }
 }


### PR DESCRIPTION
We don't need the `arrow-spacing` rule after https://github.com/vaadin/eslint-config-vaadin/pull/4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/57)
<!-- Reviewable:end -->
