### PR TITLE
Throw error when used with wrong Polymer version

### DIFF
--- a/vaadin-text-field.html
+++ b/vaadin-text-field.html
@@ -134,6 +134,10 @@ This program is available under Apache License Version 2.0, available at https:/
   </template>
 
   <script>
+    if (!Polymer.Element) {
+      throw new Error(`Unexpected Polymer version ${Polymer.version} is used, expected v2.0.0 or later.`);
+    }
+
     (function() {
       /**
        * `<vaadin-text-field>` is a Polymer element for text field control in forms.


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/251

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/96)
<!-- Reviewable:end -->
