### PR TITLE
Remove unrelated to default theme styles for error-message

### DIFF
--- a/vaadin-text-field.html
+++ b/vaadin-text-field.html
@@ -51,10 +51,6 @@ This program is available under Apache License Version 2.0, available at https:/
         margin-top: 0.25em;
         color: red;
       }
-
-      [part="error-message"][hidden] {
-         margin: 0 !important;
-      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Partly revert https://github.com/vaadin/vaadin-text-field/pull/104 according to the CR conversation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/105)
<!-- Reviewable:end -->
