### PR TITLE
Add autocapitalize="off" for password-field

### DIFF
--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -130,6 +130,7 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
           this.$.input.type = 'password';
+          this.$.input.autocapitalize = 'off';
         }
 
         _togglePasswordVisibility() {


### PR DESCRIPTION
Fixed #112 

> When the password-field text is not visible => iPhone shows lowercase keyboard. When the password-field text is visible => iPhone shows uppercase keyboard (for the first letter). Inconsistent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/111)
<!-- Reviewable:end -->
