### PR TITLE
Fix tests in IE11

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -10,6 +10,7 @@
     "gemini": false,
     "sinon": false,
     "HTMLImports": false,
-    "MockInteractions": false
+    "MockInteractions": false,
+    "animationFrameFlush": false
   }
 }

--- a/test/validation.html
+++ b/test/validation.html
@@ -28,16 +28,15 @@
 
       beforeEach(function(done) {
         iform = fixture('default');
-        window.setTimeout(function() {
-          tf = iform.querySelector('vaadin-text-field');
-          done();
-        }, 1);
+        tf = iform.querySelector('vaadin-text-field');
+        animationFrameFlush(() => {
+          HTMLImports.whenReady(done);
+        });
       });
 
-      it('should call validate', function() {
-        const inputFocusSpy = window.sinon.spy(tf, 'validate');
+      it('should call validate', function(done) {
+        sinon.stub(tf, 'validate', done);
         iform.submit();
-        expect(inputFocusSpy.called).to.be.true;
       });
 
       it('should serialize correctly', function() {


### PR DESCRIPTION
Replacing `setTimeout` with `animationFrameFlush`.
Skipping 'call validate' test on IE11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/115)
<!-- Reviewable:end -->
