### PR TITLE
API rename: hideToggleButton -> revealButtonHidden

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,17 +8,17 @@
       "sourceRange": {
         "file": "vaadin-password-field.html",
         "start": {
-          "line": 146,
+          "line": 153,
           "column": 6
         },
         "end": {
-          "line": 146,
+          "line": 153,
           "column": 42
         }
       },
       "elements": [
         {
-          "description": "`<vaadin-text-field>` is a Polymer element for text field control in forms.\n\n```html\n<vaadin-text-field label=\"First Name\">\n</vaadin-text-field>\n```\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`label` | The label element\n`value` | The input element\n`error-message` | The error message element\n`input-field` | The element that wraps prefix, value and suffix",
+          "description": "`<vaadin-text-field>` is a Polymer 2 element for text field control in forms.\n\n```html\n<vaadin-text-field label=\"First Name\">\n</vaadin-text-field>\n```\n\n### Styling\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`label` | The label element\n`value` | The input element\n`error-message` | The error message element\n`input-field` | The element that wraps prefix, value and suffix",
           "summary": "",
           "path": "vaadin-text-field.html",
           "properties": [
@@ -550,11 +550,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 115,
+                  "line": 113,
                   "column": 4
                 },
                 "end": {
-                  "line": 123,
+                  "line": 121,
                   "column": 5
                 }
               },
@@ -573,11 +573,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 125,
+                  "line": 123,
                   "column": 4
                 },
                 "end": {
-                  "line": 127,
+                  "line": 125,
                   "column": 5
                 }
               },
@@ -596,11 +596,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 129,
+                  "line": 127,
                   "column": 4
                 },
                 "end": {
-                  "line": 131,
+                  "line": 129,
                   "column": 5
                 }
               },
@@ -615,11 +615,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 142,
+                  "line": 140,
                   "column": 4
                 },
                 "end": {
-                  "line": 145,
+                  "line": 143,
                   "column": 5
                 }
               },
@@ -638,11 +638,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 152,
+                  "line": 150,
                   "column": 4
                 },
                 "end": {
-                  "line": 154,
+                  "line": 152,
                   "column": 5
                 }
               },
@@ -657,11 +657,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 156,
+                  "line": 154,
                   "column": 4
                 },
                 "end": {
-                  "line": 165,
+                  "line": 163,
                   "column": 5
                 }
               },
@@ -680,11 +680,11 @@
               "sourceRange": {
                 "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
                 "start": {
-                  "line": 167,
+                  "line": 165,
                   "column": 4
                 },
                 "end": {
-                  "line": 179,
+                  "line": 177,
                   "column": 5
                 }
               },
@@ -1417,17 +1417,519 @@
       "path": "vaadin-password-field.html",
       "properties": [
         {
-          "name": "hideToggleButton",
+          "name": "autofocus",
+          "type": "boolean",
+          "description": "Specify that this control should have input focus when the page loads.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 50,
+              "column": 8
+            },
+            "end": {
+              "line": 52,
+              "column": 9
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "focused",
+          "type": "boolean",
+          "description": "If true, the element currently has focus.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 57,
+              "column": 8
+            },
+            "end": {
+              "line": 63,
+              "column": 9
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_focusedChanged\"",
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "description": "If true, the user cannot interact with this element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 8
+            },
+            "end": {
+              "line": 72,
+              "column": 9
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_disabledChanged\""
+            }
+          },
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_parentForm",
+          "type": "Object",
+          "description": "The form that the element is registered to.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-form-element-mixin.html",
+            "start": {
+              "line": 25,
+              "column": 8
+            },
+            "end": {
+              "line": 27,
+              "column": 9
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.FormElementMixin"
+        },
+        {
+          "name": "autocomplete",
+          "type": "string",
+          "description": "Whether the value of the control can be automatically completed by the browser.\nList of available options at:\nhttps://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autocomplete",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 178,
+              "column": 12
+            },
+            "end": {
+              "line": 180,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "autocorrect",
+          "type": "string",
+          "description": "This is a property supported by Safari that is used to control whether\nautocorrection should be enabled when the user is entering/editing the text.\nPossible values are:\non: Enable autocorrection.\noff: Disable autocorrection.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 189,
+              "column": 12
+            },
+            "end": {
+              "line": 191,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "errorMessage",
+          "type": "string",
+          "description": "Error to show when the input value is invalid.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 196,
+              "column": 12
+            },
+            "end": {
+              "line": 199,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\"",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "description": "String used for the label element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 204,
+              "column": 12
+            },
+            "end": {
+              "line": 207,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\"",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "list",
+          "type": "string",
+          "description": "Identifies a list of pre-defined options to suggest to the user.\nThe value must be the id of a <datalist> element in the same document.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 213,
+              "column": 12
+            },
+            "end": {
+              "line": 215,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "maxlength",
+          "type": "number",
+          "description": "Maximum number of characters (in Unicode code points) that the user can enter.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 220,
+              "column": 12
+            },
+            "end": {
+              "line": 222,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "minlength",
+          "type": "number",
+          "description": "Minimum number of characters (in Unicode code points) that the user can enter.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 227,
+              "column": 12
+            },
+            "end": {
+              "line": 229,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the control, which is submitted with the form data.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 234,
+              "column": 12
+            },
+            "end": {
+              "line": 236,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "pattern",
+          "type": "string",
+          "description": "A regular expression that the value is checked against.\nThe pattern must match the entire value, not just some subset.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 242,
+              "column": 12
+            },
+            "end": {
+              "line": 244,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "description": "A hint to the user of what can be entered in the control.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 249,
+              "column": 12
+            },
+            "end": {
+              "line": 251,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "readonly",
+          "type": "boolean",
+          "description": "This attribute indicates that the user cannot modify the value of the control.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 256,
+              "column": 12
+            },
+            "end": {
+              "line": 258,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "required",
+          "type": "boolean",
+          "description": "Specifies that the user must fill in a value.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 263,
+              "column": 12
+            },
+            "end": {
+              "line": 265,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "description": "Message to show to the user when validation fails.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 270,
+              "column": 12
+            },
+            "end": {
+              "line": 272,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "description": "The initial value of the control.\nIt can be used for two-way data binding.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 278,
+              "column": 12
+            },
+            "end": {
+              "line": 283,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_valueChanged\""
+            }
+          },
+          "defaultValue": "\"\"",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "invalid",
+          "type": "boolean",
+          "description": "This property is set to true when the control value invalid.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 288,
+              "column": 12
+            },
+            "end": {
+              "line": 293,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "hasValue",
+          "type": "boolean",
+          "description": "A read-only property indicating whether this input has a non empty value.\nIt can be used for example in styling of the component.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 299,
+              "column": 12
+            },
+            "end": {
+              "line": 305,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "preventInvalidInput",
+          "type": "boolean",
+          "description": "When set to true, user is prevented from typing a value that\nconflicts with the given `pattern`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 311,
+              "column": 12
+            },
+            "end": {
+              "line": 313,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "_labelId",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 315,
+              "column": 12
+            },
+            "end": {
+              "line": 317,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "_errorId",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 319,
+              "column": 12
+            },
+            "end": {
+              "line": 321,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "revealButtonHidden",
           "type": "boolean",
           "description": "Set to true to hide the eye icon which toggles the password visibility.",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 94,
+              "line": 92,
               "column": 12
             },
             "end": {
-              "line": 97,
+              "line": 95,
               "column": 13
             }
           },
@@ -1443,16 +1945,17 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 102,
+              "line": 100,
               "column": 12
             },
             "end": {
-              "line": 107,
+              "line": 106,
               "column": 13
             }
           },
           "metadata": {
             "polymer": {
+              "observer": "\"_passwordVisibleChange\"",
               "readOnly": true
             }
           },
@@ -1466,11 +1969,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 129,
               "column": 8
             },
             "end": {
-              "line": 133,
+              "line": 137,
               "column": 9
             }
           },
@@ -1478,33 +1981,444 @@
           "params": []
         },
         {
+          "name": "connectedCallback",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-form-element-mixin.html",
+            "start": {
+              "line": 31,
+              "column": 4
+            },
+            "end": {
+              "line": 34,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Vaadin.FormElementMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-form-element-mixin.html",
+            "start": {
+              "line": 36,
+              "column": 4
+            },
+            "end": {
+              "line": 43,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Vaadin.FormElementMixin"
+        },
+        {
+          "name": "_focusedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 113,
+              "column": 4
+            },
+            "end": {
+              "line": 121,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "focused"
+            }
+          ],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_bodyKeydownListener",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 123,
+              "column": 4
+            },
+            "end": {
+              "line": 125,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "e"
+            }
+          ],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_bodyKeyupListener",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 4
+            },
+            "end": {
+              "line": 129,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_focus",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 140,
+              "column": 4
+            },
+            "end": {
+              "line": 143,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "e"
+            }
+          ],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "blur",
+          "description": "Native bluring in the host element does nothing because it does not have the focus.\nIn chrome it works, but not in FF.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 150,
+              "column": 4
+            },
+            "end": {
+              "line": 152,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_disabledChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 154,
+              "column": 4
+            },
+            "end": {
+              "line": 163,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "disabled"
+            }
+          ],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_tabindexChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 165,
+              "column": 4
+            },
+            "end": {
+              "line": 177,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "tabindex"
+            }
+          ],
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "_onInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 329,
+              "column": 8
+            },
+            "end": {
+              "line": 336,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "e"
+            }
+          ],
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "_valueChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 338,
+              "column": 8
+            },
+            "end": {
+              "line": 347,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "newVal"
+            },
+            {
+              "name": "oldVal"
+            }
+          ],
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "validate",
+          "description": "Returns true if `value` is valid.\n`<iron-form>` uses this to check the validity or all its elements.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 355,
+              "column": 8
+            },
+            "end": {
+              "line": 357,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the value is valid."
+          },
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "_getActiveErrorId",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 359,
+              "column": 8
+            },
+            "end": {
+              "line": 361,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "invalid"
+            },
+            {
+              "name": "errorMessage"
+            },
+            {
+              "name": "errorId"
+            }
+          ],
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "_getActiveLabelId",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 363,
+              "column": 8
+            },
+            "end": {
+              "line": 365,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "label"
+            },
+            {
+              "name": "labelId"
+            }
+          ],
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "checkValidity",
+          "description": "Returns true if the current input value satisfies all constraints (if any)",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 370,
+              "column": 8
+            },
+            "end": {
+              "line": 372,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "attributeChangedCallback",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 385,
+              "column": 8
+            },
+            "end": {
+              "line": 403,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop"
+            },
+            {
+              "name": "oldVal"
+            },
+            {
+              "name": "newVal"
+            }
+          ],
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
           "name": "_togglePasswordVisibility",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 8
             },
             "end": {
-              "line": 138,
+              "line": 141,
               "column": 9
             }
           },
           "metadata": {},
           "params": []
+        },
+        {
+          "name": "_passwordVisibleChange",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 143,
+              "column": 8
+            },
+            "end": {
+              "line": 145,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "passwordVisible"
+            }
+          ]
         }
       ],
-      "staticMethods": [],
+      "staticMethods": [
+        {
+          "name": "includeStyle",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
+            "start": {
+              "line": 38,
+              "column": 4
+            },
+            "end": {
+              "line": 42,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "moduleName"
+            }
+          ],
+          "inheritedFrom": "Vaadin.ThemableMixin"
+        }
+      ],
       "demos": [],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 84,
+          "line": 82,
           "column": 6
         },
         "end": {
-          "line": 139,
+          "line": 146,
           "column": 7
         }
       },
@@ -1513,15 +2427,375 @@
       "name": "PasswordFieldElement",
       "attributes": [
         {
-          "name": "hide-toggle-button",
-          "description": "Set to true to hide the eye icon which toggles the password visibility.",
+          "name": "autofocus",
+          "description": "Specify that this control should have input focus when the page loads.",
           "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
             "start": {
-              "line": 94,
+              "line": 50,
+              "column": 8
+            },
+            "end": {
+              "line": 52,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "focused",
+          "description": "If true, the element currently has focus.",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 57,
+              "column": 8
+            },
+            "end": {
+              "line": 63,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "disabled",
+          "description": "If true, the user cannot interact with this element.",
+          "sourceRange": {
+            "file": "bower_components/vaadin-control-state-mixin/vaadin-control-state-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 8
+            },
+            "end": {
+              "line": 72,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.ControlStateMixin"
+        },
+        {
+          "name": "autocomplete",
+          "description": "Whether the value of the control can be automatically completed by the browser.\nList of available options at:\nhttps://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autocomplete",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 178,
               "column": 12
             },
             "end": {
-              "line": 97,
+              "line": 180,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "autocorrect",
+          "description": "This is a property supported by Safari that is used to control whether\nautocorrection should be enabled when the user is entering/editing the text.\nPossible values are:\non: Enable autocorrection.\noff: Disable autocorrection.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 189,
+              "column": 12
+            },
+            "end": {
+              "line": 191,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "error-message",
+          "description": "Error to show when the input value is invalid.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 196,
+              "column": 12
+            },
+            "end": {
+              "line": 199,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "label",
+          "description": "String used for the label element.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 204,
+              "column": 12
+            },
+            "end": {
+              "line": 207,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "list",
+          "description": "Identifies a list of pre-defined options to suggest to the user.\nThe value must be the id of a <datalist> element in the same document.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 213,
+              "column": 12
+            },
+            "end": {
+              "line": 215,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "maxlength",
+          "description": "Maximum number of characters (in Unicode code points) that the user can enter.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 220,
+              "column": 12
+            },
+            "end": {
+              "line": 222,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "minlength",
+          "description": "Minimum number of characters (in Unicode code points) that the user can enter.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 227,
+              "column": 12
+            },
+            "end": {
+              "line": 229,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "name",
+          "description": "The name of the control, which is submitted with the form data.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 234,
+              "column": 12
+            },
+            "end": {
+              "line": 236,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "pattern",
+          "description": "A regular expression that the value is checked against.\nThe pattern must match the entire value, not just some subset.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 242,
+              "column": 12
+            },
+            "end": {
+              "line": 244,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "placeholder",
+          "description": "A hint to the user of what can be entered in the control.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 249,
+              "column": 12
+            },
+            "end": {
+              "line": 251,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "readonly",
+          "description": "This attribute indicates that the user cannot modify the value of the control.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 256,
+              "column": 12
+            },
+            "end": {
+              "line": 258,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "required",
+          "description": "Specifies that the user must fill in a value.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 263,
+              "column": 12
+            },
+            "end": {
+              "line": 265,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "title",
+          "description": "Message to show to the user when validation fails.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 270,
+              "column": 12
+            },
+            "end": {
+              "line": 272,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "value",
+          "description": "The initial value of the control.\nIt can be used for two-way data binding.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 278,
+              "column": 12
+            },
+            "end": {
+              "line": 283,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "invalid",
+          "description": "This property is set to true when the control value invalid.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 288,
+              "column": 12
+            },
+            "end": {
+              "line": 293,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "has-value",
+          "description": "A read-only property indicating whether this input has a non empty value.\nIt can be used for example in styling of the component.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 299,
+              "column": 12
+            },
+            "end": {
+              "line": 305,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "prevent-invalid-input",
+          "description": "When set to true, user is prevented from typing a value that\nconflicts with the given `pattern`.",
+          "sourceRange": {
+            "file": "vaadin-text-field.html",
+            "start": {
+              "line": 311,
+              "column": 12
+            },
+            "end": {
+              "line": 313,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean",
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "name": "reveal-button-hidden",
+          "description": "Set to true to hide the eye icon which toggles the password visibility.",
+          "sourceRange": {
+            "start": {
+              "line": 92,
+              "column": 12
+            },
+            "end": {
+              "line": 95,
               "column": 13
             }
           },
@@ -1533,11 +2807,11 @@
           "description": "True if the password is visible ([type=text]).",
           "sourceRange": {
             "start": {
-              "line": 102,
+              "line": 100,
               "column": 12
             },
             "end": {
-              "line": 107,
+              "line": 106,
               "column": 13
             }
           },
@@ -1545,7 +2819,43 @@
           "type": "boolean"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "iron-form-element-register",
+          "description": "iron-form-element-register",
+          "metadata": {},
+          "inheritedFrom": "Vaadin.FormElementMixin"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "iron-form-element-unregister",
+          "description": "iron-form-element-unregister",
+          "metadata": {},
+          "inheritedFrom": "Vaadin.FormElementMixin"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "value-changed",
+          "description": "Fired when the `value` property changes.",
+          "metadata": {},
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "invalid-changed",
+          "description": "Fired when the `invalid` property changes.",
+          "metadata": {},
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        },
+        {
+          "type": "CustomEvent",
+          "name": "has-value-changed",
+          "description": "Fired when the `hasValue` property changes.",
+          "metadata": {},
+          "inheritedFrom": "Vaadin.TextFieldElement"
+        }
+      ],
       "styling": {
         "cssVariables": [],
         "selectors": []

--- a/demo/password.html
+++ b/demo/password.html
@@ -27,7 +27,7 @@
     <h3>Password Field with Hidden Eye Icon</h3>
     <demo-snippet>
       <template>
-        <vaadin-password-field placeholder="Password" hide-toggle-button></vaadin-password-field>
+        <vaadin-password-field placeholder="Password" reveal-button-hidden></vaadin-password-field>
       </template>
     </demo-snippet>
 

--- a/test/password-field.html
+++ b/test/password-field.html
@@ -20,12 +20,12 @@
   <script>
 
     describe('password-field', function() {
-      var passwordField, input, toggleButton;
+      var passwordField, input, revealButton;
 
       beforeEach(function() {
         passwordField = fixture('default');
         input = passwordField.$.input;
-        toggleButton = passwordField.root.querySelector('[part=toggle-button]');
+        revealButton = passwordField.root.querySelector('[part=reveal-button]');
       });
 
       describe('password visibility', function() {
@@ -33,11 +33,11 @@
           expect(input.type).to.equal('password');
         });
 
-        it('should toggle type on click on eye-icons', function() {
-          toggleButton.click();
+        it('should reveal password on click on eye-icons', function() {
+          revealButton.click();
           expect(input.type).to.equal('text');
 
-          toggleButton.click();
+          revealButton.click();
           expect(input.type).to.equal('password');
         });
 
@@ -52,11 +52,11 @@
       });
 
       describe('eye-icons', function() {
-        it('should hide eye-icon when hideToggleButton is set to true', function() {
-          expect(toggleButton.hidden).to.be.false;
+        it('should hide eye-icon when revealButtonHidden is set to true', function() {
+          expect(revealButton.hidden).to.be.false;
 
-          passwordField.hideToggleButton = true;
-          expect(toggleButton.hidden).to.be.true;
+          passwordField.revealButtonHidden = true;
+          expect(revealButton.hidden).to.be.true;
         });
       });
 

--- a/test/password-field.html
+++ b/test/password-field.html
@@ -33,7 +33,7 @@
           expect(input.type).to.equal('password');
         });
 
-        it('should reveal password on click on eye-icons', function() {
+        it('should reveal the password on click on eye-icons', function() {
           revealButton.click();
           expect(input.type).to.equal('text');
 
@@ -43,7 +43,7 @@
 
         it('should hide the password on blur', function() {
           passwordField.focus();
-          toggleButton.click();
+          revealButton.click();
           expect(input.type).to.equal('text');
 
           passwordField.dispatchEvent(new Event('blur'));

--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -19,7 +19,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-password-field-default-theme">
   <template>
     <style>
-      [part="toggle-button"] {
+      [part="reveal-button"] {
         cursor: pointer;
       }
     </style>
@@ -29,15 +29,15 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-password-field-template">
   <template>
     <style>
-      [part="toggle-button"] {
+      [part="reveal-button"] {
         font-family: 'vaadin-password-field-icons';
       }
 
-      [part="toggle-button"]::before {
+      [part="reveal-button"]::before {
         content: "\e900";
       }
 
-      :host([password-visible]) [part="toggle-button"]::before {
+      :host([password-visible]) [part="reveal-button"]::before {
         content: "\e901";
       }
 
@@ -48,9 +48,9 @@ This program is available under Apache License Version 2.0, available at https:/
     </style>
 
     <div
-      part="toggle-button"
+      part="reveal-button"
       on-click="_togglePasswordVisibility"
-      hidden$="[[hideToggleButton]]">
+      hidden$="[[revealButtonHidden]]">
     </div>
   </template>
   <script>
@@ -71,7 +71,7 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * Part name       | Description
        * ----------------|----------------------------------------------------
-       * `toggle-button` | The eye icon which toggles the password visibility
+       * `reveal-button` | The eye icon which toggles the password visibility
        *
        * @memberof Vaadin
        * @extends Vaadin.TextFieldElement
@@ -90,7 +90,7 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              * Set to true to hide the eye icon which toggles the password visibility.
              */
-            hideToggleButton: {
+            revealButtonHidden: {
               type: Boolean,
               value: false
             },
@@ -115,12 +115,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
             // Retrieve this element's dom-module template
             const thisTemplate = Polymer.DomModule.import(this.is + '-template', 'template');
-            const toggleButton = thisTemplate.content.querySelector('[part="toggle-button"]');
+            const revealButton = thisTemplate.content.querySelector('[part="reveal-button"]');
             const styles = thisTemplate.content.querySelector('style');
 
-            // Append toggle-button and styles to the text-field template
+            // Append reveal-button and styles to the text-field template
             const inputField = memoizedTemplate.content.querySelector('[part="input-field"]');
-            inputField.appendChild(toggleButton);
+            inputField.appendChild(revealButton);
             memoizedTemplate.content.appendChild(styles);
           }
 

--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -75,7 +75,7 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * @memberof Vaadin
        * @extends Vaadin.TextFieldElement
-       * @demo demo/index.html
+       * @demo demo/password.html
        */
 
       let memoizedTemplate;


### PR DESCRIPTION
This PR renames `hideToggleButton` to `revealButtonHidden`. 

- the `toggle` -> `reveal` part of renaming was requested by @Jouni https://github.com/vaadin/vaadin-text-field/pull/114#issuecomment-323037271
- the `hide*` to `*Hidden` part of renaming was suggested by @tomivirkki, the reason is in Flow-side there will be getters and setters, `getRevealButtonHidden()` is much in readability then `getHideRevealButton()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/122)
<!-- Reviewable:end -->
