### PR TITLE
Remove themable-mixin from password-field

### DIFF
--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -5,7 +5,6 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../polymer/polymer-element.html">
-<link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="vaadin-text-field.html">
 
 <style>
@@ -81,7 +80,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       let memoizedTemplate;
 
-      class PasswordFieldElement extends Vaadin.ThemableMixin(Vaadin.TextFieldElement) {
+      class PasswordFieldElement extends Vaadin.TextFieldElement {
         static get is() {
           return 'vaadin-password-field';
         }


### PR DESCRIPTION
It's already extended in the `text-field`: https://github.com/vaadin/vaadin-text-field/blob/master/vaadin-text-field.html#L167

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/123)
<!-- Reviewable:end -->
