### PR TITLE
Add ability to prevent focus on prefix/suffix click

### DIFF
--- a/test/text-field.html
+++ b/test/text-field.html
@@ -13,18 +13,29 @@
 <body>
   <test-fixture id="default">
     <template>
-      <vaadin-text-field></vaadin-text-field>
+      <vaadin-text-field>
+        <div slot="prefix">
+          <div>prefix</div>
+        </div>
+        <div slot="suffix">
+          <div>suffix</div>
+        </div>
+      </vaadin-text-field>
     </template>
   </test-fixture>
 
   <script>
 
     describe('properties', function() {
-      var textField, input;
+      var textField, input, slots;
 
       beforeEach(function() {
         textField = fixture('default');
         input = textField.$.input;
+        slots = {
+          prefix: textField.querySelector('[slot=prefix] div'),
+          suffix: textField.querySelector('[slot=suffix] div')
+        };
       });
 
       describe('native', function() {
@@ -75,6 +86,21 @@
           it('should set boolean attribute ' + prop, function() {
             assertAttrCanBeSet(prop, true);
             assertAttrCanBeSet(prop, false);
+          });
+        });
+      });
+
+      describe('prefix-suffix', () => {
+        ['prefix', 'suffix'].forEach((slot) => {
+          it(`should focus input on ${slot} click by default`, () => {
+            slots[slot].dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+            expect(textField.focused).to.be.true;
+          });
+
+          it(`should not focus input on ${slot} click if prevent-focus is set`, () => {
+            slots[slot].setAttribute('prevent-focus', '');
+            slots[slot].dispatchEvent(new CustomEvent('click', {bubbles: true, composed: true}));
+            expect(textField.focused).not.to.be.true;
           });
         });
       });

--- a/vaadin-text-field.html
+++ b/vaadin-text-field.html
@@ -92,7 +92,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     </style>
 
-    <div class="container">
+    <div class="container" id="container">
 
       <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
 
@@ -347,6 +347,16 @@ This program is available under Apache License Version 2.0, available at https:/
           this._setHasValue(newVal !== '' && newVal != null);
         }
 
+        _clickHandler(e) {
+          let target = e.target;
+          while (target !== this) {
+            if (target.hasAttribute('prevent-focus')) {
+              return e.stopPropagation();
+            }
+            target = target.parentNode;
+          }
+        }
+
         /**
          * Returns true if `value` is valid.
          * `<iron-form>` uses this to check the validity or all its elements.
@@ -381,6 +391,8 @@ This program is available under Apache License Version 2.0, available at https:/
           var uniqueId = TextFieldElement._uniqueId = 1 + TextFieldElement._uniqueId || 0;
           this._errorId = `${this.constructor.is}-error-${uniqueId}`;
           this._labelId = `${this.constructor.is}-label-${uniqueId}`;
+
+          this.$.container.addEventListener('click', this._clickHandler);
         }
 
         attributeChangedCallback(prop, oldVal, newVal) {


### PR DESCRIPTION
This PR is a dependency for https://github.com/vaadin/vaadin-combo-box/pull/507

`control-state-mixin` listens to the `click` event on host and focus the `focusElement` after click. This PR will stop `click` event propagation from prefix/suffix to the host if `prevent-focus` attribute is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/131)
<!-- Reviewable:end -->
