### PR TITLE
Fix label click test

### DIFF
--- a/test/text-field.html
+++ b/test/text-field.html
@@ -119,9 +119,9 @@
 
       if (!window.ShadyDOM) {
         describe('label', function() {
-          it('should focus the internal input on click', function() {
+          it('should focus the internal input on mousedown', function() {
             const label = textField.root.querySelector('[part="label"]');
-            label.click();
+            label.dispatchEvent(new CustomEvent('mousedown', {bubbles: true, composed: true}));
             expect(textField.focused).to.be.true;
           });
 


### PR DESCRIPTION
After merging https://github.com/vaadin/vaadin-control-state-mixin/pull/17 small change is needed for label-click test

Current master is broken: https://travis-ci.org/vaadin/vaadin-text-field/builds/272056097

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/135)
<!-- Reviewable:end -->
