### PR TITLE
Prefix classes, remove id='input' to avoid collisions

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -58,7 +58,7 @@
     <h3>Right-To-Left</h3>
     <demo-snippet>
       <template>
-        <div class="container" dir="rtl">
+        <div dir="rtl">
           <vaadin-text-field label="كلمه السر" placeholder="أنشئ كلمة مرور"></vaadin-text-field>
           <vaadin-text-field label="البادئة واللاحقة">
             <span slot="prefix">اختصار</span>

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -44,7 +44,7 @@
 
         beforeEach(function() {
           tf = fixture('default');
-          input = tf.$.input;
+          input = tf.focusElement;
           label = tf.root.querySelector('[part=label]');
         });
 
@@ -78,10 +78,11 @@
       });
 
       describe('error', function() {
-        let tf, err;
+        let tf, err, input;
 
         beforeEach(function() {
           tf = fixture('error-fixture');
+          input = tf.focusElement;
           err = tf.root.querySelector('[part=error-message]');
         });
 
@@ -105,12 +106,12 @@
         });
 
         it('should not have aria-describedby attribute if valid', function() {
-          expect(tf.$.input.hasAttribute('aria-describedby')).to.be.false;
+          expect(input.hasAttribute('aria-describedby')).to.be.false;
         });
 
         it('should have aria-describedby attribute when invalid', function() {
           tf.validate();
-          expect(tf.$.input.getAttribute('aria-describedby')).to.equal(err.id);
+          expect(input.getAttribute('aria-describedby')).to.equal(err.id);
         });
 
         it('should have appropriate aria-live attribute', function() {
@@ -125,7 +126,7 @@
         beforeEach(function() {
           tf = fixture('invalid-fixture');
           err = tf.root.querySelector('[part=error-message]');
-          input = tf.$.input;
+          input = tf.focusElement;
         });
 
         it('should show the error if initially invalid', function() {

--- a/test/password-field.html
+++ b/test/password-field.html
@@ -24,7 +24,7 @@
 
       beforeEach(function() {
         passwordField = fixture('default');
-        input = passwordField.$.input;
+        input = passwordField.focusElement;
         revealButton = passwordField.root.querySelector('[part=reveal-button]');
       });
 

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -24,7 +24,7 @@
 
       beforeEach(function() {
         textField = fixture('default');
-        input = textField.$.input;
+        input = textField.focusElement;
       });
 
       describe('native', function() {

--- a/test/validation.html
+++ b/test/validation.html
@@ -24,11 +24,12 @@
   <script>
 
     describe('validate', function() {
-      let iform, tf;
+      let iform, tf, input;
 
       beforeEach(function(done) {
         iform = fixture('default');
         tf = iform.querySelector('vaadin-text-field');
+        input = tf.focusElement;
         animationFrameFlush(() => {
           HTMLImports.whenReady(done);
         });
@@ -85,8 +86,8 @@
         describe('user action', function() {
 
           function userSetValue(value) {
-            tf.$.input.value = value;
-            tf.$.input.dispatchEvent(new CustomEvent('input'));
+            input.value = value;
+            input.dispatchEvent(new CustomEvent('input'));
           }
 
           it('should prevent invalid pattern', function() {

--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -129,8 +129,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         ready() {
           super.ready();
-          this.$.input.type = 'password';
-          this.$.input.autocapitalize = 'off';
+          this.focusElement.type = 'password';
+          this.focusElement.autocapitalize = 'off';
 
           this.addEventListener('blur', () => {
             this._setPasswordVisible(false);
@@ -142,7 +142,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _passwordVisibleChange(passwordVisible) {
-          this.$.input.type = passwordVisible ? 'text' : 'password';
+          this.focusElement.type = passwordVisible ? 'text' : 'password';
         }
       }
 

--- a/vaadin-text-field.html
+++ b/vaadin-text-field.html
@@ -64,7 +64,7 @@ This program is available under Apache License Version 2.0, available at https:/
         outline: none;
       }
 
-      .container {
+      .vaadin-text-field-container {
         display: flex;
         flex-direction: column;
         position: relative;
@@ -92,7 +92,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     </style>
 
-    <div class="container">
+    <div class="vaadin-text-field-container">
 
       <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
 
@@ -100,7 +100,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         <slot name="prefix"></slot>
 
-        <input id="input" part="value"
+        <input part="value"
           autocomplete$="[[autocomplete]]"
           autocorrect$="[[autocorrect]]"
           autofocus$="[[autofocus]]"
@@ -324,12 +324,12 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         get focusElement() {
-          return this.$.input;
+          return this.root.querySelector('[part=value]');
         }
 
         _onInput(e) {
           if (this.preventInvalidInput) {
-            const input = this.$.input;
+            const input = this.focusElement;
             if (input.value.length > 0 && !this.checkValidity()) {
               input.value = this.value || '';
             }
@@ -369,7 +369,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * Returns true if the current input value satisfies all constraints (if any)
          */
         checkValidity() {
-          return this.$.input.checkValidity();
+          return this.focusElement.checkValidity();
         }
 
         ready() {


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/280

Fixes https://gitlab.vaadin.com/vaadincom/webpage/issues/1764

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/142)
<!-- Reviewable:end -->
