### PR TITLE
Move reveal button icon styles from core styles to the default theme

### DIFF
--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -20,17 +20,8 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       [part="reveal-button"] {
-        cursor: pointer;
-      }
-    </style>
-  </template>
-</dom-module>
-
-<dom-module id="vaadin-password-field-template">
-  <template>
-    <style>
-      [part="reveal-button"] {
         font-family: 'vaadin-password-field-icons';
+        cursor: pointer;
       }
 
       [part="reveal-button"]::before {
@@ -40,7 +31,13 @@ This program is available under Apache License Version 2.0, available at https:/
       :host([password-visible]) [part="reveal-button"]::before {
         content: "\e901";
       }
+    </style>
+  </template>
+</dom-module>
 
+<dom-module id="vaadin-password-field-template">
+  <template>
+    <style>
       /* Hide the native eye icon for IE/Edge */
       ::-ms-reveal {
         display: none;


### PR DESCRIPTION
Having the icon styles in the core styles makes it more difficult to override them in a new theme, as the core styles come after the theme in the source order, so the theme needs to use more specific selectors to override them.

Also, these are purely aesthetic aspects of the component, so they should be in the theme.

It is still very easy for a developer to get those styles in their own theme if needed, by including the default theme in their own theme:

```html
<dom-module id="valo-password-field" theme-for="vaadin-password-field">
<template>
<style include="vaadin-password-field-default-theme">
…
</style>
</template>
</dom-module>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/148)
<!-- Reviewable:end -->
