### PR TITLE
Make readonly property reflect to attribute

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "vaadin-text-area.html",
         "start": {
-          "line": 173,
+          "line": 179,
           "column": 6
         },
         "end": {
-          "line": 173,
+          "line": 179,
           "column": 42
         }
       },
@@ -316,7 +316,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -333,11 +333,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -354,11 +354,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -379,11 +379,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -403,11 +403,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -428,11 +428,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -449,11 +449,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 177,
+                  "line": 178,
                   "column": 10
                 },
                 "end": {
-                  "line": 179,
+                  "line": 180,
                   "column": 11
                 }
               },
@@ -470,11 +470,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 181,
+                  "line": 182,
                   "column": 10
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 11
                 }
               },
@@ -490,11 +490,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 147,
+                  "line": 151,
                   "column": 12
                 },
                 "end": {
-                  "line": 149,
+                  "line": 153,
                   "column": 13
                 }
               },
@@ -509,11 +509,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 155,
+                  "line": 159,
                   "column": 12
                 },
                 "end": {
-                  "line": 157,
+                  "line": 161,
                   "column": 13
                 }
               },
@@ -528,11 +528,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 163,
+                  "line": 167,
                   "column": 12
                 },
                 "end": {
-                  "line": 165,
+                  "line": 169,
                   "column": 13
                 }
               },
@@ -547,11 +547,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 170,
+                  "line": 174,
                   "column": 12
                 },
                 "end": {
-                  "line": 172,
+                  "line": 176,
                   "column": 13
                 }
               },
@@ -568,11 +568,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 223,
+                  "line": 224,
                   "column": 6
                 },
                 "end": {
-                  "line": 232,
+                  "line": 233,
                   "column": 7
                 }
               },
@@ -797,11 +797,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 191,
+                  "line": 192,
                   "column": 6
                 },
                 "end": {
-                  "line": 198,
+                  "line": 199,
                   "column": 7
                 }
               },
@@ -820,11 +820,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 200,
+                  "line": 201,
                   "column": 6
                 },
                 "end": {
-                  "line": 209,
+                  "line": 210,
                   "column": 7
                 }
               },
@@ -846,11 +846,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 214,
+                  "line": 215,
                   "column": 6
                 },
                 "end": {
-                  "line": 220,
+                  "line": 221,
                   "column": 7
                 }
               },
@@ -865,11 +865,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 240,
+                  "line": 241,
                   "column": 6
                 },
                 "end": {
-                  "line": 242,
+                  "line": 243,
                   "column": 7
                 }
               },
@@ -888,11 +888,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 244,
+                  "line": 245,
                   "column": 6
                 },
                 "end": {
-                  "line": 246,
+                  "line": 247,
                   "column": 7
                 }
               },
@@ -917,11 +917,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 248,
+                  "line": 249,
                   "column": 6
                 },
                 "end": {
-                  "line": 250,
+                  "line": 251,
                   "column": 7
                 }
               },
@@ -943,11 +943,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 255,
+                  "line": 256,
                   "column": 6
                 },
                 "end": {
-                  "line": 273,
+                  "line": 274,
                   "column": 7
                 }
               },
@@ -1000,11 +1000,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 131,
+              "line": 135,
               "column": 6
             },
             "end": {
-              "line": 175,
+              "line": 179,
               "column": 7
             }
           },
@@ -1184,7 +1184,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -1198,11 +1198,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -1216,11 +1216,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -1234,11 +1234,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -1252,11 +1252,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -1270,11 +1270,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -1287,11 +1287,11 @@
               "description": "This is a property supported by Safari that is used to control whether\nautocorrection should be enabled when the user is entering/editing the text.\nPossible values are:\non: Enable autocorrection.\noff: Disable autocorrection.",
               "sourceRange": {
                 "start": {
-                  "line": 147,
+                  "line": 151,
                   "column": 12
                 },
                 "end": {
-                  "line": 149,
+                  "line": 153,
                   "column": 13
                 }
               },
@@ -1303,11 +1303,11 @@
               "description": "Identifies a list of pre-defined options to suggest to the user.\nThe value must be the id of a <datalist> element in the same document.",
               "sourceRange": {
                 "start": {
-                  "line": 155,
+                  "line": 159,
                   "column": 12
                 },
                 "end": {
-                  "line": 157,
+                  "line": 161,
                   "column": 13
                 }
               },
@@ -1319,11 +1319,11 @@
               "description": "A regular expression that the value is checked against.\nThe pattern must match the entire value, not just some subset.",
               "sourceRange": {
                 "start": {
-                  "line": 163,
+                  "line": 167,
                   "column": 12
                 },
                 "end": {
-                  "line": 165,
+                  "line": 169,
                   "column": 13
                 }
               },
@@ -1335,11 +1335,11 @@
               "description": "Message to show to the user when validation fails.",
               "sourceRange": {
                 "start": {
-                  "line": 170,
+                  "line": 174,
                   "column": 12
                 },
                 "end": {
-                  "line": 172,
+                  "line": 176,
                   "column": 13
                 }
               },
@@ -1374,11 +1374,11 @@
               "range": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 58,
+                  "line": 62,
                   "column": 8
                 },
                 "end": {
-                  "line": 58,
+                  "line": 62,
                   "column": 35
                 }
               }
@@ -1389,11 +1389,11 @@
               "range": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 83,
+                  "line": 87,
                   "column": 8
                 },
                 "end": {
-                  "line": 83,
+                  "line": 87,
                   "column": 35
                 }
               }
@@ -1704,7 +1704,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -1721,11 +1721,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -1742,11 +1742,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -1767,11 +1767,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -1791,11 +1791,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -1816,11 +1816,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -1837,11 +1837,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 177,
+                  "line": 178,
                   "column": 10
                 },
                 "end": {
-                  "line": 179,
+                  "line": 180,
                   "column": 11
                 }
               },
@@ -1858,11 +1858,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 181,
+                  "line": 182,
                   "column": 10
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 11
                 }
               },
@@ -1879,11 +1879,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 147,
+                  "line": 151,
                   "column": 12
                 },
                 "end": {
-                  "line": 149,
+                  "line": 153,
                   "column": 13
                 }
               },
@@ -1900,11 +1900,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 155,
+                  "line": 159,
                   "column": 12
                 },
                 "end": {
-                  "line": 157,
+                  "line": 161,
                   "column": 13
                 }
               },
@@ -1921,11 +1921,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 163,
+                  "line": 167,
                   "column": 12
                 },
                 "end": {
-                  "line": 165,
+                  "line": 169,
                   "column": 13
                 }
               },
@@ -1942,11 +1942,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 170,
+                  "line": 174,
                   "column": 12
                 },
                 "end": {
-                  "line": 172,
+                  "line": 176,
                   "column": 13
                 }
               },
@@ -2234,11 +2234,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 191,
+                  "line": 192,
                   "column": 6
                 },
                 "end": {
-                  "line": 198,
+                  "line": 199,
                   "column": 7
                 }
               },
@@ -2257,11 +2257,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 200,
+                  "line": 201,
                   "column": 6
                 },
                 "end": {
-                  "line": 209,
+                  "line": 210,
                   "column": 7
                 }
               },
@@ -2283,11 +2283,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 214,
+                  "line": 215,
                   "column": 6
                 },
                 "end": {
-                  "line": 220,
+                  "line": 221,
                   "column": 7
                 }
               },
@@ -2302,11 +2302,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 240,
+                  "line": 241,
                   "column": 6
                 },
                 "end": {
-                  "line": 242,
+                  "line": 243,
                   "column": 7
                 }
               },
@@ -2325,11 +2325,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 244,
+                  "line": 245,
                   "column": 6
                 },
                 "end": {
-                  "line": 246,
+                  "line": 247,
                   "column": 7
                 }
               },
@@ -2354,11 +2354,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 248,
+                  "line": 249,
                   "column": 6
                 },
                 "end": {
-                  "line": 250,
+                  "line": 251,
                   "column": 7
                 }
               },
@@ -2380,11 +2380,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 255,
+                  "line": 256,
                   "column": 6
                 },
                 "end": {
-                  "line": 273,
+                  "line": 274,
                   "column": 7
                 }
               },
@@ -2680,7 +2680,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -2694,11 +2694,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -2712,11 +2712,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -2730,11 +2730,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -2748,11 +2748,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -2766,11 +2766,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -2784,11 +2784,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 147,
+                  "line": 151,
                   "column": 12
                 },
                 "end": {
-                  "line": 149,
+                  "line": 153,
                   "column": 13
                 }
               },
@@ -2802,11 +2802,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 155,
+                  "line": 159,
                   "column": 12
                 },
                 "end": {
-                  "line": 157,
+                  "line": 161,
                   "column": 13
                 }
               },
@@ -2820,11 +2820,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 163,
+                  "line": 167,
                   "column": 12
                 },
                 "end": {
-                  "line": 165,
+                  "line": 169,
                   "column": 13
                 }
               },
@@ -2838,11 +2838,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 170,
+                  "line": 174,
                   "column": 12
                 },
                 "end": {
-                  "line": 172,
+                  "line": 176,
                   "column": 13
                 }
               },
@@ -2907,7 +2907,7 @@
           "tagname": "vaadin-password-field"
         },
         {
-          "description": "`<vaadin-text-area>` is a Polymer 2 element for text area control in forms.\n\n```html\n<vaadin-text-area label=\"Add description\">\n</vaadin-text-area>\n```\n\n### Styling\n\n[Generic styling/theming documentation](https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html)\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`label` | The label element\n`value` | The textarea element\n`error-message` | The error message element\n`text-area` | The element that wraps prefix, value and suffix\n\nThe following state attributes are available for styling:\n\nAttribute    | Description | Part name\n-------------|-------------|------------\n`disabled` | Set to a disabled text field | :host\n`has-value` | Set when the element has a value | :host\n`invalid` | Set when the element is invalid | :host\n`focused` | Set when the element is focused | :host\n`focus-ring` | Set when the element is keyboard focused | :host",
+          "description": "`<vaadin-text-area>` is a Polymer 2 element for text area control in forms.\n\n```html\n<vaadin-text-area label=\"Add description\">\n</vaadin-text-area>\n```\n\n### Styling\n\n[Generic styling/theming documentation](https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html)\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`label` | The label element\n`value` | The textarea element\n`error-message` | The error message element\n`text-area` | The element that wraps prefix, value and suffix\n\nThe following state attributes are available for styling:\n\nAttribute    | Description | Part name\n-------------|-------------|------------\n`disabled` | Set to a disabled text field | :host\n`has-value` | Set when the element has a value | :host\n`invalid` | Set when the element is invalid | :host\n`focused` | Set when the element is focused | :host\n`focus-ring` | Set when the element is keyboard focused | :host\n`readonly` | Set to a readonly text field | :host",
           "summary": "",
           "path": "vaadin-text-area.html",
           "properties": [
@@ -3205,7 +3205,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -3222,11 +3222,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -3243,11 +3243,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -3268,11 +3268,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -3292,11 +3292,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -3317,11 +3317,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -3338,11 +3338,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 177,
+                  "line": 178,
                   "column": 10
                 },
                 "end": {
-                  "line": 179,
+                  "line": 180,
                   "column": 11
                 }
               },
@@ -3359,11 +3359,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 181,
+                  "line": 182,
                   "column": 10
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 11
                 }
               },
@@ -3379,19 +3379,17 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 223,
-                  "column": 6
+                  "line": 140,
+                  "column": 8
                 },
                 "end": {
-                  "line": 232,
-                  "column": 7
+                  "line": 143,
+                  "column": 9
                 }
               },
               "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.TextFieldMixin"
+              "params": []
             },
             {
               "name": "connectedCallback",
@@ -3610,11 +3608,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 191,
+                  "line": 192,
                   "column": 6
                 },
                 "end": {
-                  "line": 198,
+                  "line": 199,
                   "column": 7
                 }
               },
@@ -3633,11 +3631,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 200,
+                  "line": 201,
                   "column": 6
                 },
                 "end": {
-                  "line": 209,
+                  "line": 210,
                   "column": 7
                 }
               },
@@ -3659,11 +3657,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 214,
+                  "line": 215,
                   "column": 6
                 },
                 "end": {
-                  "line": 220,
+                  "line": 221,
                   "column": 7
                 }
               },
@@ -3678,11 +3676,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 240,
+                  "line": 241,
                   "column": 6
                 },
                 "end": {
-                  "line": 242,
+                  "line": 243,
                   "column": 7
                 }
               },
@@ -3701,11 +3699,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 244,
+                  "line": 245,
                   "column": 6
                 },
                 "end": {
-                  "line": 246,
+                  "line": 247,
                   "column": 7
                 }
               },
@@ -3730,11 +3728,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 248,
+                  "line": 249,
                   "column": 6
                 },
                 "end": {
-                  "line": 250,
+                  "line": 251,
                   "column": 7
                 }
               },
@@ -3756,11 +3754,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 255,
+                  "line": 256,
                   "column": 6
                 },
                 "end": {
-                  "line": 273,
+                  "line": 274,
                   "column": 7
                 }
               },
@@ -3784,11 +3782,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 139,
+                  "line": 145,
                   "column": 8
                 },
                 "end": {
-                  "line": 141,
+                  "line": 147,
                   "column": 9
                 }
               },
@@ -3805,11 +3803,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 143,
+                  "line": 149,
                   "column": 8
                 },
                 "end": {
-                  "line": 165,
+                  "line": 171,
                   "column": 9
                 }
               },
@@ -3851,11 +3849,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 128,
+              "line": 129,
               "column": 6
             },
             "end": {
-              "line": 166,
+              "line": 172,
               "column": 7
             }
           },
@@ -4035,7 +4033,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -4049,11 +4047,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -4067,11 +4065,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -4085,11 +4083,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -4103,11 +4101,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -4121,11 +4119,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -4575,7 +4573,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -4590,11 +4588,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -4609,11 +4607,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -4632,11 +4630,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -4654,11 +4652,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -4677,11 +4675,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },
@@ -4696,11 +4694,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 177,
+                  "line": 178,
                   "column": 10
                 },
                 "end": {
-                  "line": 179,
+                  "line": 180,
                   "column": 11
                 }
               },
@@ -4715,11 +4713,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 181,
+                  "line": 182,
                   "column": 10
                 },
                 "end": {
-                  "line": 183,
+                  "line": 184,
                   "column": 11
                 }
               },
@@ -4735,11 +4733,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 223,
+                  "line": 224,
                   "column": 6
                 },
                 "end": {
-                  "line": 232,
+                  "line": 233,
                   "column": 7
                 }
               },
@@ -4962,11 +4960,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 191,
+                  "line": 192,
                   "column": 6
                 },
                 "end": {
-                  "line": 198,
+                  "line": 199,
                   "column": 7
                 }
               },
@@ -4983,11 +4981,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 200,
+                  "line": 201,
                   "column": 6
                 },
                 "end": {
-                  "line": 209,
+                  "line": 210,
                   "column": 7
                 }
               },
@@ -5007,11 +5005,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 214,
+                  "line": 215,
                   "column": 6
                 },
                 "end": {
-                  "line": 220,
+                  "line": 221,
                   "column": 7
                 }
               },
@@ -5024,11 +5022,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 240,
+                  "line": 241,
                   "column": 6
                 },
                 "end": {
-                  "line": 242,
+                  "line": 243,
                   "column": 7
                 }
               },
@@ -5045,11 +5043,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 244,
+                  "line": 245,
                   "column": 6
                 },
                 "end": {
-                  "line": 246,
+                  "line": 247,
                   "column": 7
                 }
               },
@@ -5072,11 +5070,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 248,
+                  "line": 249,
                   "column": 6
                 },
                 "end": {
-                  "line": 250,
+                  "line": 251,
                   "column": 7
                 }
               },
@@ -5096,11 +5094,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 255,
+                  "line": 256,
                   "column": 6
                 },
                 "end": {
-                  "line": 273,
+                  "line": 274,
                   "column": 7
                 }
               },
@@ -5127,7 +5125,7 @@
               "column": 4
             },
             "end": {
-              "line": 274,
+              "line": 275,
               "column": 5
             }
           },
@@ -5291,7 +5289,7 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 126,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -5303,11 +5301,11 @@
               "description": "Specifies that the user must fill in a value.",
               "sourceRange": {
                 "start": {
-                  "line": 131,
+                  "line": 132,
                   "column": 10
                 },
                 "end": {
-                  "line": 133,
+                  "line": 134,
                   "column": 11
                 }
               },
@@ -5319,11 +5317,11 @@
               "description": "The initial value of the control.\nIt can be used for two-way data binding.",
               "sourceRange": {
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 10
                 },
                 "end": {
-                  "line": 145,
+                  "line": 146,
                   "column": 11
                 }
               },
@@ -5335,11 +5333,11 @@
               "description": "This property is set to true when the control value is invalid.",
               "sourceRange": {
                 "start": {
-                  "line": 150,
+                  "line": 151,
                   "column": 10
                 },
                 "end": {
-                  "line": 155,
+                  "line": 156,
                   "column": 11
                 }
               },
@@ -5351,11 +5349,11 @@
               "description": "A read-only property indicating whether this input has a non empty value.\nIt can be used for example in styling of the component.",
               "sourceRange": {
                 "start": {
-                  "line": 161,
+                  "line": 162,
                   "column": 10
                 },
                 "end": {
-                  "line": 167,
+                  "line": 168,
                   "column": 11
                 }
               },
@@ -5367,11 +5365,11 @@
               "description": "When set to true, user is prevented from typing a value that\nconflicts with the given `pattern`.",
               "sourceRange": {
                 "start": {
-                  "line": 173,
+                  "line": 174,
                   "column": 10
                 },
                 "end": {
-                  "line": 175,
+                  "line": 176,
                   "column": 11
                 }
               },

--- a/vaadin-text-area.html
+++ b/vaadin-text-area.html
@@ -120,6 +120,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * `invalid` | Set when the element is invalid | :host
        * `focused` | Set when the element is focused | :host
        * `focus-ring` | Set when the element is keyboard focused | :host
+       * `readonly` | Set to a readonly text field | :host
        *
        * @memberof Vaadin
        * @mixes Vaadin.TextFieldMixin

--- a/vaadin-text-field-mixin.html
+++ b/vaadin-text-field-mixin.html
@@ -123,7 +123,8 @@ This program is available under Apache License Version 2.0, available at https:/
            * This attribute indicates that the user cannot modify the value of the control.
            */
           readonly: {
-            type: Boolean
+            type: Boolean,
+            reflectToAttribute: true
           },
 
           /**

--- a/vaadin-text-field.html
+++ b/vaadin-text-field.html
@@ -127,6 +127,7 @@ This program is available under Apache License Version 2.0, available at https:/
        * `invalid` | Set when the element is invalid | :host
        * `focused` | Set when the element is focused | :host
        * `focus-ring` | Set when the element is keyboard focused | :host
+       * `readonly` | Set to a readonly text field | :host
        *
        * @memberof Vaadin
        * @mixes Vaadin.TextFieldMixin

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -7,7 +7,7 @@ module.exports = {
       'macOS 10.12/ipad@10.3',
       'Windows 10/microsoftedge@15',
       'Windows 10/internet explorer@11',
-      'macOS 10.12/safari@10.0'
+      'macOS 10.12/safari@11.0'
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-combo-box/issues/548
Fixes https://github.com/vaadin/vaadin-date-picker/issues/444

Add `reflectToAttribute` key to `readonly` property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/158)
<!-- Reviewable:end -->
