### PR TITLE
Make required property reflect to attribute

### DIFF
--- a/vaadin-text-field-mixin.html
+++ b/vaadin-text-field-mixin.html
@@ -130,7 +130,8 @@ This program is available under Apache License Version 2.0, available at https:/
            * Specifies that the user must fill in a value.
            */
           required: {
-            type: Boolean
+            type: Boolean,
+            reflectToAttribute: true
           },
 
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-date-picker/issues/424

Add `reflectToAttribute` key to `required` property

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/159)
<!-- Reviewable:end -->
