### PR TITLE
Make sure the field has focus when revealed

### DIFF
--- a/test/password-field.html
+++ b/test/password-field.html
@@ -59,10 +59,17 @@
           expect(revealButton.hidden).to.be.true;
         });
 
-        it('should prevent mousedown event on reveal-button', function() {
+        it('should prevent mousedown event on reveal-button when focused', function() {
           const e = new CustomEvent('mousedown', {bubbles: true, cancelable: true});
+          passwordField.focus();
           revealButton.dispatchEvent(e);
           expect(e.defaultPrevented).to.be.true;
+        });
+
+        it('should not prevent mousedown event on reveal-button when not focused', function() {
+          const e = new CustomEvent('mousedown', {bubbles: true, cancelable: true});
+          revealButton.dispatchEvent(e);
+          expect(e.defaultPrevented).to.be.false;
         });
       });
 

--- a/vaadin-password-field.html
+++ b/vaadin-password-field.html
@@ -46,7 +46,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <div
       part="reveal-button"
-      on-mousedown="_preventDefault"
+      on-mousedown="_revealButtonMouseDown"
       on-click="_togglePasswordVisibility"
       hidden$="[[revealButtonHidden]]">
     </div>
@@ -146,8 +146,10 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
-        _preventDefault(e) {
-          e.preventDefault();
+        _revealButtonMouseDown(e) {
+          if (this.hasAttribute('focused')) {
+            e.preventDefault();
+          }
         }
 
         _togglePasswordVisibility() {


### PR DESCRIPTION
Fixes #116

There was a regression in v1.1.0 that caused the field not getting focused on password reveal (if not focused beforehand). The issue is described in [this comment](https://github.com/vaadin/vaadin-text-field/issues/116#issuecomment-346966907)

This PR fixes the regression

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/174)
<!-- Reviewable:end -->
