### PR TITLE
Ensure text area styles override text field styles in text area

### DIFF
--- a/theme/valo/vaadin-text-area.html
+++ b/theme/valo/vaadin-text-area.html
@@ -5,7 +5,7 @@
 
 <dom-module id="valo-text-area" theme-for="vaadin-text-area">
   <template>
-    <style>
+    <style include="valo-text-field">
       :host {
         width: calc(var(--valo-size-m) * 10);
       }

--- a/theme/valo/vaadin-text-field.html
+++ b/theme/valo/vaadin-text-field.html
@@ -14,7 +14,7 @@
   </style>
 </custom-style>
 
-<dom-module id="valo-text-field" theme-for="vaadin-text-field vaadin-text-area">
+<dom-module id="valo-text-field" theme-for="vaadin-text-field">
   <template>
     <style>
       :host {


### PR DESCRIPTION
The order in which matching style modules are included in an element template is not consistent.

So the current approach makes the theme look broken in case text field styles get included _after_ text area specific styles (that are supposed to override text-field styles) in the text area template.

Need to add an explicit include for text field valo styles prior to text-area specific styles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/176)
<!-- Reviewable:end -->
