### PR TITLE
Restructure demos (plus minor theme updates)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "polymer": "^2.0.0",
     "vaadin-themable-mixin": "^1.1.0",
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.0.0",
-    "vaadin-valo-theme": "^2.0.0",
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.0.1"
   }
 }

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,11 +2,41 @@
   "name": "Vaadin Text Field",
   "pages": [
     {
-      "name": "Basic Examples",
+      "name": "Basics",
       "url": "text-field-basic-demos",
       "src": "text-field-basic-demos.html",
       "meta": {
-        "title": "vaadin-text-field Basic Examples",
+        "title": "Vaadin Text Field Basic Examples",
+        "description": "",
+        "image": ""
+      }
+    },
+    {
+      "name": "Prefix and Suffix",
+      "url": "text-field-prefix-suffix-demos",
+      "src": "text-field-prefix-suffix-demos.html",
+      "meta": {
+        "title": "Vaadin Text Field Prefix and Suffix Examples",
+        "description": "",
+        "image": ""
+      }
+    },
+    {
+      "name": "Validation",
+      "url": "text-field-validators-demos",
+      "src": "text-field-validators-demos.html",
+      "meta": {
+        "title": "Vaadin Text Field Validation Examples",
+        "description": "",
+        "image": ""
+      }
+    },
+    {
+      "name": "RTL",
+      "url": "text-field-rtl-demos",
+      "src": "text-field-rtl-demos.html",
+      "meta": {
+        "title": "Vaadin Text Field RTL Examples",
         "description": "",
         "image": ""
       }
@@ -16,37 +46,37 @@
       "url": "text-field-password-demos",
       "src": "text-field-password-demos.html",
       "meta": {
-        "title": "vaadin-password-field Basic Examples",
+        "title": "Vaadin Password Field Examples",
         "description": "",
         "image": ""
       }
     },
     {
-      "name": "Text area",
+      "name": "Text Area",
       "url": "text-area-demos",
       "src": "text-area-demos.html",
       "meta": {
-        "title": "vaadin-text-area Basic Examples",
+        "title": "Vaadin Text Area Examples",
         "description": "",
         "image": ""
       }
     },
     {
-      "name": "Custom Validators",
-      "url": "text-field-validators-demos",
-      "src": "text-field-validators-demos.html",
+      "name": "Styling",
+      "url": "text-field-styling-demos",
+      "src": "text-field-styling-demos.html",
       "meta": {
-        "title": "vaadin-text-field Custom Validators",
+        "title": "Vaadin Text Field Styling Examples",
         "description": "",
         "image": ""
       }
     },
     {
-      "name": "Valo Theme Variations",
+      "name": "Valo Theme",
       "url": "text-field-valo-theme-demos",
       "src": "text-field-valo-theme-demos.html",
       "meta": {
-        "title": "vaadin-text-field Valo Theme Variations",
+        "title": "Vaadin Text Field Valo Theme Variations",
         "description": "",
         "image": ""
       }

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,14 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
-  <title>vaadin-text-field Examples</title>
+  <title>Vaadin Text Field Examples</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <style>
-    body {
-      font-family: sans-serif;
-    }
-  </style>
+  <custom-style>
+     <style include="vaadin-component-demo-shared-styles"></style>
+   </custom-style>
 </head>
 
 <body>
@@ -21,12 +19,28 @@
 
   <link rel="import" href="text-field-demo.html">
 
-  <link rel="import" href="../../paper-styles/default-theme.html">
   <link rel="import" href="../vaadin-text-field.html">
   <link rel="import" href="../vaadin-password-field.html">
   <link rel="import" href="../vaadin-text-area.html">
   <link rel="import" href="../../iron-form/iron-form.html">
+  <link rel="import" href="../../vaadin-valo-theme/icons.html">
 
   <vaadin-component-demo config-src="demos.json"></vaadin-component-demo>
+
+  <!-- Used in the styling examples, keep in sync -->
+  <dom-module id="my-text-field-styles" theme-for="vaadin-text-field vaadin-text-area">
+    <template>
+      <style>
+        :host(.custom-style) [part="input-field"] {
+          border: 1px solid #CCC;
+          background-color: #FFF;
+        }
+
+        :host([focused].custom-style) [part="input-field"] {
+          border-color: #AAA;
+        }
+      </style>
+    </template>
+  </dom-module>
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,7 +23,7 @@
   <link rel="import" href="../vaadin-password-field.html">
   <link rel="import" href="../vaadin-text-area.html">
   <link rel="import" href="../../iron-form/iron-form.html">
-  <link rel="import" href="../../vaadin-valo-theme/icons.html">
+  <link rel="import" href="../../vaadin-valo-styles/icons.html">
 
   <vaadin-component-demo config-src="demos.json"></vaadin-component-demo>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -32,12 +32,12 @@
     <template>
       <style>
         :host(.custom-style) [part="input-field"] {
-          border: 1px solid #CCC;
-          background-color: #FFF;
+          border: 1px solid #ccc;
+          background-color: #fff;
         }
 
         :host([focused].custom-style) [part="input-field"] {
-          border-color: #AAA;
+          border-color: #aaa;
         }
       </style>
     </template>

--- a/demo/text-area-demos.html
+++ b/demo/text-area-demos.html
@@ -1,24 +1,24 @@
 <dom-module id="text-area-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
     </style>
 
+    <p>The <code>&lt;vaadin-text-area&gt;</code> element has all the same features as the <code>&lt;vaadin-text-field&gt;</code> element. The only difference is that a text field always single-line and text area is always multi-line.</p>
 
-    <h3>Default Text area</h3>
-    <vaadin-demo-snippet id='text-area-demos-default-text-area'>
+    <h3>Basic Text Area</h3>
+    <vaadin-demo-snippet id="text-area-demos-default-text-area">
       <template preserve-content>
         <vaadin-text-area
             label="Write a description"
-            placeholder="Add detailed explanation">
-        </vaadin-text-area>
+            placeholder="Add detailed explanation"></vaadin-text-area>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Text area with max height</h3>
-    <vaadin-demo-snippet id='text-area-demos-text-area-with-max-height'>
+    <h3>Maximum Height</h3>
+    <vaadin-demo-snippet id="text-area-demos-text-area-with-max-height">
       <template preserve-content>
         <style>
           vaadin-text-area.max-height {
@@ -28,13 +28,12 @@
         <vaadin-text-area
             class="max-height"
             label="Text area growing stops at 150px"
-            placeholder="Add more text here">
-        </vaadin-text-area>
+            placeholder="Add more text here"></vaadin-text-area>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Text area with min height</h3>
-    <vaadin-demo-snippet id='text-area-demos-text-area-with-min-height'>
+    <h3>Minimum Height</h3>
+    <vaadin-demo-snippet id="text-area-demos-text-area-with-min-height">
       <template preserve-content>
         <style>
           vaadin-text-area.min-height {
@@ -43,7 +42,7 @@
         </style>
         <vaadin-text-area
             class="min-height"
-            label="Text area won't shrink under 150px"
+            label="Text area won’t shrink under 150px"
             placeholder="Add more text here">
         </vaadin-text-area>
       </template>

--- a/demo/text-field-basic-demos.html
+++ b/demo/text-field-basic-demos.html
@@ -27,16 +27,6 @@
     </vaadin-demo-snippet>
 
 
-    <h3>Text Align</h3>
-    <vaadin-demo-snippet id="text-field-basic-demos-text-align">
-      <template preserve-content>
-        <vaadin-text-field value="left"></vaadin-text-field>
-        <vaadin-text-field value="center" theme="align-center"></vaadin-text-field>
-        <vaadin-text-field value="right" theme="align-right"></vaadin-text-field>
-      </template>
-    </vaadin-demo-snippet>
-
-
   </div>
   </template>
   <script>

--- a/demo/text-field-basic-demos.html
+++ b/demo/text-field-basic-demos.html
@@ -1,180 +1,41 @@
 <dom-module id="text-field-basic-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
     </style>
 
 
-    <h3>Setting the Value</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-setting-the-value'>
+    <h3>Label, Placeholder and Value</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-label-placeholder-value">
       <template preserve-content>
-        <vaadin-text-field value="foo"></vaadin-text-field>
+        <vaadin-text-field label="Label"></vaadin-text-field>
+        <vaadin-text-field placeholder="Placeholder"></vaadin-text-field>
+        <vaadin-text-field value="Value"></vaadin-text-field>
       </template>
     </vaadin-demo-snippet>
 
 
-    <h3>Label</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-label'>
+    <h3>States</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-states">
       <template preserve-content>
-        <vaadin-text-field label="Foo" value="bar"></vaadin-text-field>
+        <vaadin-text-field label="Enabled" value="Value"></vaadin-text-field>
+        <vaadin-text-field label="Disabled" value="Value" disabled></vaadin-text-field>
+        <vaadin-text-field label="Read only" value="Value" readonly></vaadin-text-field>
       </template>
     </vaadin-demo-snippet>
 
 
-    <h3>Prefix and Suffix</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-prefix-and-suffix'>
+    <h3>Text Align</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-text-align">
       <template preserve-content>
-        <vaadin-text-field label="Sum" value="1000">
-          <div slot="prefix">$</div>
-        </vaadin-text-field>
-        <br>
-        <br>
-        <vaadin-text-field label="Email">
-          <div slot="suffix">@vaadin.com</div>
-        </vaadin-text-field>
+        <vaadin-text-field value="left"></vaadin-text-field>
+        <vaadin-text-field value="center" theme="align-center"></vaadin-text-field>
+        <vaadin-text-field value="right" theme="align-right"></vaadin-text-field>
       </template>
     </vaadin-demo-snippet>
 
-
-    <h3>TabIndex</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-tabindex'>
-      <template preserve-content>
-        <vaadin-text-field tabindex="4" placeholder="TabIndex 4"></vaadin-text-field>
-        <vaadin-text-field tabindex="3" placeholder="TabIndex 3"></vaadin-text-field>
-        <vaadin-text-field tabindex="2" placeholder="TabIndex 2 disabled" disabled></vaadin-text-field>
-        <vaadin-text-field tabindex="1" placeholder="TabIndex 1"></vaadin-text-field>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Right-To-Left</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-right-to-left'>
-      <template preserve-content>
-        <div class="container" dir="rtl">
-          <vaadin-text-field label="كلمه السر" placeholder="أنشئ كلمةالسر "></vaadin-text-field>
-          <vaadin-text-field label="البادئة و اللاحقة">
-            <span slot="prefix">البادئة</span>
-            <span slot="suffix">لاحقة</span>
-          </vaadin-text-field>
-        </div>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Data Binding</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-data-binding'>
-      <template preserve-content>
-        <dom-bind id="demo-bind1">
-          <template>
-            <vaadin-text-field id="input1" value="{{value}}"></vaadin-text-field>
-            <vaadin-text-field id="input2" value="{{value}}"></vaadin-text-field>
-            <span>[[value]]</span>
-          </template>
-        </dom-bind>
-
-        <script>
-         window.addDemoReadyListener('#text-field-basic-demos-data-binding', function(document) {
-           var domBind = document.querySelector('#demo-bind1');
-           domBind.value = 'bar';
-         });
-        </script>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Required Input</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-required-input'>
-      <template preserve-content>
-        <p><vaadin-text-field required value="foo"></vaadin-text-field> is valid</p>
-        <p><vaadin-text-field required value=""></vaadin-text-field> is invalid</p>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Minlength and Maxlength Validation</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-minlength-and-maxlength-validation'>
-      <template preserve-content>
-        <p><vaadin-text-field required minlength="2"></vaadin-text-field> type at least 2 characters</p>
-        <p><vaadin-text-field maxlength="4"></vaadin-text-field> you cannot type more than 4 characters</p>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Pattern Validation</h3>
-    <p>
-      The <code>pattern</code> property specifies a regular expression that the element's value is checked against.
-    </p>
-    <vaadin-demo-snippet id='text-field-basic-demos-pattern-validation'>
-      <template preserve-content>
-        <p><vaadin-text-field pattern="\d\d\d*" required></vaadin-text-field> type 2 numbers or more</p>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Preventing Invalid Input</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-preventing-invalid-input'>
-      <template preserve-content>
-        <p><vaadin-text-field pattern="[0-9]*" prevent-invalid-input></vaadin-text-field> Can type numbers only</p>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Error Message</h3>
-    <p>
-      The <code>errorMessage</code> property defines a message that gets shown when the input value is invalid.
-    </p>
-    <p>
-      <b>NOTE: The message is not visible initially or when the field is valid</b>
-    </p>
-    <vaadin-demo-snippet id='text-field-basic-demos-error-message'>
-      <template preserve-content>
-        <p><vaadin-text-field required error-message="You must write something in this input"></vaadin-text-field> Required content</p>
-      </template>
-    </vaadin-demo-snippet>
-
-
-    <h3>Full Form</h3>
-    <vaadin-demo-snippet id='text-field-basic-demos-full-form'>
-      <template preserve-content>
-        <h4>Registration Form</h4>
-        <iron-form>
-          <form>
-            <div>
-              <vaadin-text-field label="User Name" minlength="4" maxlength="8" required pattern="^\w+$"></vaadin-text-field>
-              <span>* from 4 to 8 characters without spaces</span>
-            </div>
-            <div>
-              <vaadin-text-field label="Email" required></vaadin-text-field>
-              <span>*</span>
-            </div>
-            <div>
-              <vaadin-text-field label="Initials" minlength="3" maxlength="3"></vaadin-text-field>
-              <span>3 characters</span>
-            </div>
-            <div>
-              <vaadin-text-field label="Age" pattern="\d\d\d*" required></vaadin-text-field>
-              <span>* 2 digits age</span>
-            </div>
-            <div>
-              <vaadin-text-field label="Password" required pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}"></vaadin-text-field>
-              <span>* 6 characters min including uppercase and number</span>
-            </div>
-            <div style="margin-top: 1.5em;">
-              <button onclick="_submit()">Submit</button>
-            </div>
-          </form>
-        </iron-form>
-        <script>
-          window._submit = function() {
-            if (!document.querySelector('iron-form').validate()) {
-              window.alert('Please fill all required fields with valid values');
-            }
-          };
-        </script>
-      </template>
-    </vaadin-demo-snippet>
 
   </div>
   </template>

--- a/demo/text-field-form-demos.html
+++ b/demo/text-field-form-demos.html
@@ -1,0 +1,43 @@
+<dom-module id="text-field-form-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+
+    <h3>Form Integration</h3>
+    <vaadin-demo-snippet id="text-field-form-demos-basic">
+      <template preserve-content>
+        <iron-form>
+          <form>
+            <vaadin-text-field label="User Name" minlength="4" maxlength="8" required pattern="^\w+$" error-message="4–8 charaters, no spaces"></vaadin-text-field>
+            <br>
+            <vaadin-text-field label="Email" required error-message="Please enter a valid email address"></vaadin-text-field>
+            <br>
+            <vaadin-text-field label="Initials" minlength="3" maxlength="3" error-message="Exactly 3 characters"></vaadin-text-field>
+            <br>
+            <vaadin-text-field label="Age" pattern="\d\d\d*" required error-message="10 years or older"></vaadin-text-field>
+            <br>
+            <vaadin-password-field label="Password" required pattern="(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{6,}" error-message="6 characters minimum, including uppercase and number"></vaadin-password-field>
+            <br>
+            <br>
+            <vaadin-button>Submit</vaadin-button>
+          </form>
+        </iron-form>
+      </template>
+    </vaadin-demo-snippet>
+
+
+  </div>
+  </template>
+  <script>
+    class TextFieldFormDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {
+      static get is() {
+        return 'text-field-form-demos';
+      }
+    }
+    customElements.define(TextFieldFormDemos.is, TextFieldFormDemos);
+  </script>
+</dom-module>

--- a/demo/text-field-password-demos.html
+++ b/demo/text-field-password-demos.html
@@ -1,24 +1,42 @@
 <dom-module id="text-field-password-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
     </style>
 
+    <p>The <code>&lt;vaadin-password-field&gt;</code> element has all the same features as the <code>&lt;vaadin-text-field&gt;</code> element plus the additional features listed on this page.</p>
 
-    <h3>Default Password Field</h3>
-    <vaadin-demo-snippet id='text-field-password-demos-default-password-field'>
+    <h3>Basic Password Field</h3>
+    <vaadin-demo-snippet id="text-field-password-demos-basic-password-field">
       <template preserve-content>
-        <vaadin-password-field label="Password" placeholder="Create a password"></vaadin-password-field>
+        <vaadin-password-field label="Password" placeholder="Enter password" value="secret1"></vaadin-password-field>
       </template>
     </vaadin-demo-snippet>
 
 
-    <h3>Password Field with Hidden Eye Icon</h3>
-    <vaadin-demo-snippet id='text-field-password-demos-password-field-with-hidden-eye-icon'>
+    <h3>Hide the Reveal Button</h3>
+    <p>You can easily hide the reveal button of an individual password field.</p>
+    <vaadin-demo-snippet id="text-field-password-demos-password-field-with-hidden-eye-icon">
       <template preserve-content>
-        <vaadin-password-field placeholder="Password" reveal-button-hidden></vaadin-password-field>
+        <vaadin-password-field label="Password" value="secret1" reveal-button-hidden></vaadin-password-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Hide the Reveal Button (CSS)</h3>
+    <p>You can also use CSS to hide the reveal button. It can be used to easily hide the reveal button across the whole application.</p>
+    <vaadin-demo-snippet id="text-field-password-demos-password-field-with-hidden-eye-icon">
+      <template preserve-content>
+        <custom-style>
+          <style>
+            vaadin-password-field {
+              --valo-password-field-reveal-button-display: none;
+            }
+          </style>
+        </custom-style>
+        <vaadin-password-field label="Password" value="secret1"></vaadin-password-field>
       </template>
     </vaadin-demo-snippet>
 

--- a/demo/text-field-password-demos.html
+++ b/demo/text-field-password-demos.html
@@ -24,22 +24,6 @@
       </template>
     </vaadin-demo-snippet>
 
-
-    <h3>Hide the Reveal Button (CSS)</h3>
-    <p>You can also use CSS to hide the reveal button. It can be used to easily hide the reveal button across the whole application.</p>
-    <vaadin-demo-snippet id="text-field-password-demos-password-field-with-hidden-eye-icon">
-      <template preserve-content>
-        <custom-style>
-          <style>
-            vaadin-password-field {
-              --valo-password-field-reveal-button-display: none;
-            }
-          </style>
-        </custom-style>
-        <vaadin-password-field label="Password" value="secret1"></vaadin-password-field>
-      </template>
-    </vaadin-demo-snippet>
-
   </div>
   </template>
   <script>

--- a/demo/text-field-prefix-suffix-demos.html
+++ b/demo/text-field-prefix-suffix-demos.html
@@ -1,0 +1,48 @@
+<dom-module id="text-field-prefix-suffix-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+
+    <h3>Text</h3>
+    <vaadin-demo-snippet id="text-field-prefix-suffix-demos-basic">
+      <template preserve-content>
+        <vaadin-text-field label="Dollars" value="1000" style="width: 6em;">
+          <div slot="prefix">$</div>
+        </vaadin-text-field>
+
+        <vaadin-text-field label="Euros" value="1000" theme="align-right" style="width: 6em;">
+          <div slot="suffix">€</div>
+        </vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Icons</h3>
+    <vaadin-demo-snippet id="text-field-prefix-suffix-demos-basic">
+      <template preserve-content>
+        <vaadin-text-field placeholder="Search">
+          <iron-icon icon="valo:magnifier" slot="prefix"></iron-icon>
+        </vaadin-text-field>
+
+        <vaadin-text-field value="joe@example.com">
+          <iron-icon icon="valo:checkmark" slot="suffix"></iron-icon>
+        </vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+  </div>
+  </template>
+  <script>
+    class TextFieldPrefixSuffixDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {
+      static get is() {
+        return 'text-field-prefix-suffix-demos';
+      }
+    }
+    customElements.define(TextFieldPrefixSuffixDemos.is, TextFieldPrefixSuffixDemos);
+  </script>
+</dom-module>

--- a/demo/text-field-rtl-demos.html
+++ b/demo/text-field-rtl-demos.html
@@ -1,0 +1,35 @@
+<dom-module id="text-field-rtl-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+
+    <h3>Right-to-Left Support</h3>
+    <vaadin-demo-snippet id="text-field-rtl-demos-basic">
+      <template preserve-content>
+        <div dir="rtl">
+          <vaadin-text-field label="كلمه السر" placeholder="أنشئ كلمةالسر "></vaadin-text-field>
+
+          <vaadin-text-field label="البادئة و اللاحقة">
+            <span slot="prefix">البادئة</span>
+            <span slot="suffix">لاحقة</span>
+          </vaadin-text-field>
+        </div>
+      </template>
+    </vaadin-demo-snippet>
+
+
+  </div>
+  </template>
+  <script>
+    class TextFieldRtlDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {
+      static get is() {
+        return 'text-field-rtl-demos';
+      }
+    }
+    customElements.define(TextFieldRtlDemos.is, TextFieldRtlDemos);
+  </script>
+</dom-module>

--- a/demo/text-field-styling-demos.html
+++ b/demo/text-field-styling-demos.html
@@ -1,0 +1,46 @@
+<dom-module id="text-field-styling-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <p>Read more about writing custom CSS for themable elements from the <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">styling and theming documentation</a>.</p>
+
+    <h3>Custom Border and Background</h3>
+    <vaadin-demo-snippet id="text-field-styling-demos-border-styles">
+    <vaadin-demo-snippet id="text-field-valo-theme-demos-sizes">
+      <template preserve-content>
+        <vaadin-text-field class="custom-style" label="Label" value="Value"></vaadin-text-field>
+        <vaadin-password-field class="custom-style" label="Label" value="Value"></vaadin-password-field>
+        <vaadin-text-area class="custom-style" label="Label" value="Value"></vaadin-text-area>
+
+        <!-- Place in index.html or in a separate HTML import -->
+        <dom-module id="my-text-field-styles" theme-for="vaadin-text-field vaadin-text-area">
+          <template>
+            <style>
+              :host(.custom-style) [part="input-field"] {
+                border: 1px solid #CCC;
+                background-color: #FFF;
+              }
+
+              :host([focused].custom-style) [part="input-field"] {
+                border-color: #AAA;
+              }
+            </style>
+          </template>
+        </dom-module>
+      </template>
+    </vaadin-demo-snippet>
+
+  </template>
+  <script>
+    class TextFieldStylingDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {
+      static get is() {
+        return 'text-field-styling-demos';
+      }
+    }
+    customElements.define(TextFieldStylingDemos.is, TextFieldStylingDemos);
+  </script>
+</dom-module>

--- a/demo/text-field-styling-demos.html
+++ b/demo/text-field-styling-demos.html
@@ -10,7 +10,6 @@
 
     <h3>Custom Border and Background</h3>
     <vaadin-demo-snippet id="text-field-styling-demos-border-styles">
-    <vaadin-demo-snippet id="text-field-valo-theme-demos-sizes">
       <template preserve-content>
         <vaadin-text-field class="custom-style" label="Label" value="Value"></vaadin-text-field>
         <vaadin-password-field class="custom-style" label="Label" value="Value"></vaadin-password-field>
@@ -21,12 +20,12 @@
           <template>
             <style>
               :host(.custom-style) [part="input-field"] {
-                border: 1px solid #CCC;
-                background-color: #FFF;
+                border: 1px solid #ccc;
+                background-color: #fff;
               }
 
               :host([focused].custom-style) [part="input-field"] {
-                border-color: #AAA;
+                border-color: #aaa;
               }
             </style>
           </template>

--- a/demo/text-field-validators-demos.html
+++ b/demo/text-field-validators-demos.html
@@ -1,19 +1,67 @@
 <dom-module id="text-field-validators-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
     </style>
 
+    <p>Fields are validated on blur. If a field is already invalid, its validity is checked on
+      each key input so that the user gets immediate feedback when the field is again valid.</p>
+
+    <h3>Required</h3>
+    <p>A required field cannot be left empty.</p>
+    <vaadin-demo-snippet id="text-field-basic-demos-required-input">
+      <template preserve-content>
+        <vaadin-text-field required label="Required"></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Error Message</h3>
+    <p>The error message is visible <em>only</em> when the field value is invalid.</p>
+    <vaadin-demo-snippet id="text-field-basic-demos-error-message">
+      <template preserve-content>
+        <vaadin-text-field error-message="Please enter a value" required invalid label="Required"></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Minlength and Maxlength</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-minlength-and-maxlength-validation">
+      <template preserve-content>
+        <vaadin-text-field minlength="2" label="Min 2 characters"></vaadin-text-field>
+        <vaadin-text-field maxlength="4" label="Max 4 characters"></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Pattern</h3>
+    <p>The <code>pattern</code> property specifies a regular expression that the element’s value is
+      checked against.</p>
+    <vaadin-demo-snippet id="text-field-basic-demos-pattern-validation">
+      <template preserve-content>
+        <vaadin-text-field pattern="\d\d\d*" label="Min 2 numbers"></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
+    <h3>Prevent Invalid Input</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-preventing-invalid-input">
+      <template preserve-content>
+        <vaadin-text-field prevent-invalid-input pattern="[0-9]*" label="Numbers only"></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
     <h3>Synchronous Custom Validator</h3>
 
     <p>Extend <code>Vaadin.TextFieldElement</code> to create your own custom element,
-      then override the <code>checkValidity()</code> method to validate the user's input</p>
+      then override the <code>checkValidity()</code> method to validate the user’s input.</p>
 
-    <vaadin-demo-snippet id='text-field-validators-demos-synchronous-custom-validator'>
+    <vaadin-demo-snippet id="text-field-validators-demos-synchronous-custom-validator">
       <template preserve-content>
-        <employee-role-text-field label='Position'></employee-role-text-field>
+        <employee-role-text-field label="Position"></employee-role-text-field>
         Valid options: Architect, Developer or Designer
 
         <script>
@@ -41,10 +89,10 @@
       then override the <code>checkValidity()</code> to make your asynchronous validation,
       and finally set the <code>invalid</code> flag appropriately in the callback.</p>
 
-    <vaadin-demo-snippet id='text-field-validators-demos-asynchronous-custom-validator'>
+    <vaadin-demo-snippet id="text-field-validators-demos-asynchronous-custom-validator">
       <template preserve-content>
-        <my-ajax id='ajax1' handle-as='json' url='https://vaadin.com/validate-element'></my-ajax>
-        <chemical-element-text-field label='Element Name'></chemical-element-text-field>
+        <my-ajax id="ajax1" handle-as="json" url="https://vaadin.com/validate-element"></my-ajax>
+        <chemical-element-text-field label="Element Name"></chemical-element-text-field>
         Type a valid Chemical Element such as Hydrogen, Oxygen, Carbon, etc.
 
         <script>
@@ -61,7 +109,7 @@
                 this.ajax.addEventListener('response', function() {
                   var elementName = this.value || '';
                   this.invalid = this.ajax.lastResponse.elements.indexOf(elementName.toLowerCase()) < 0;
-                  this.errorMessage = this.invalid ? '"' + elementName + '" is not a Chemical Element' : '';
+                  this.errorMessage = this.invalid ? `${elementName} is not a Chemical Element` : '';
                 }.bind(this));
               }
 
@@ -79,7 +127,7 @@
     </vaadin-demo-snippet>
   </div>
 
-  <dom-module id='my-ajax'>
+  <dom-module id="my-ajax">
     <template>
     </template>
     <script>

--- a/demo/text-field-valo-theme-demos.html
+++ b/demo/text-field-valo-theme-demos.html
@@ -7,6 +7,16 @@
     </style>
 
 
+    <h3>Text Align</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-text-align">
+      <template preserve-content>
+        <vaadin-text-field value="left"></vaadin-text-field>
+        <vaadin-text-field value="center" theme="align-center"></vaadin-text-field>
+        <vaadin-text-field value="right" theme="align-right"></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
     <h3>Small Size</h3>
     <vaadin-demo-snippet id="text-field-valo-theme-demos-sizes">
       <template preserve-content>

--- a/demo/text-field-valo-theme-demos.html
+++ b/demo/text-field-valo-theme-demos.html
@@ -27,6 +27,23 @@
     </vaadin-demo-snippet>
 
 
+    <h3>Hide the Password Field Reveal Button (CSS)</h3>
+    <p>You can also use CSS to hide the reveal button (in addition to the <code>reveal-button-hidden</code>
+      attribute). It can be used to easily hide the reveal button across the whole application.</p>
+    <vaadin-demo-snippet id="text-field-valo-theme-demos-password-field-hide-reveal-button">
+      <template preserve-content>
+        <custom-style>
+          <style>
+            vaadin-password-field {
+              --valo-password-field-reveal-button-display: none;
+            }
+          </style>
+        </custom-style>
+        <vaadin-password-field label="Password" value="secret1"></vaadin-password-field>
+      </template>
+    </vaadin-demo-snippet>
+
+
   </template>
   <script>
     class TextFieldValoThemeDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {

--- a/demo/text-field-valo-theme-demos.html
+++ b/demo/text-field-valo-theme-demos.html
@@ -1,24 +1,21 @@
 <dom-module id="text-field-valo-theme-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
       :host {
         display: block;
       }
     </style>
 
-    <h3>Small</h3>
-    <vaadin-demo-snippet id='text-field-valo-theme-demos-small'>
+
+    <h3>Small Size</h3>
+    <vaadin-demo-snippet id="text-field-valo-theme-demos-sizes">
       <template preserve-content>
-        <vaadin-text-field theme="small" label="Small" placeholder="Placeholder"></vaadin-text-field>
+        <vaadin-text-field theme="small" label="Label" placeholder="Text field"></vaadin-text-field>
+        <vaadin-password-field theme="small" label="Label" placeholder="Password field"></vaadin-password-field>
+        <vaadin-text-area theme="small" label="Label" placeholder="Text area"></vaadin-text-area>
       </template>
     </vaadin-demo-snippet>
 
-    <h3>Contrast</h3>
-    <vaadin-demo-snippet id='text-field-valo-theme-demos-contrast'>
-      <template preserve-content>
-        <vaadin-text-field theme="contrast" label="Contrast" placeholder="Placeholder" value="Value"></vaadin-text-field>
-      </template>
-    </vaadin-demo-snippet>
 
   </template>
   <script>

--- a/demo/text-field-valo-theme-demos.html
+++ b/demo/text-field-valo-theme-demos.html
@@ -8,7 +8,7 @@
 
 
     <h3>Text Align</h3>
-    <vaadin-demo-snippet id="text-field-basic-demos-text-align">
+    <vaadin-demo-snippet id="text-field-valo-theme-demos-text-align">
       <template preserve-content>
         <vaadin-text-field value="left"></vaadin-text-field>
         <vaadin-text-field value="center" theme="align-center"></vaadin-text-field>

--- a/src/vaadin-password-field.html
+++ b/src/vaadin-password-field.html
@@ -23,6 +23,10 @@ This program is available under Apache License Version 2.0, available at https:/
       ::-ms-reveal {
         display: none;
       }
+
+      [part="reveal-button"][hidden] {
+        display: none !important;
+      }
     </style>
 
     <div

--- a/test/visual/vaadin-password-field/valo.html
+++ b/test/visual/vaadin-password-field/valo.html
@@ -2,7 +2,7 @@
 <script src="../../../../webcomponentsjs/webcomponents-loader.js"></script>
 <link href="../../../vaadin-password-field.html" rel="import">
 <link href="../../../../vaadin-button/vaadin-button.html" rel="import">
-<link rel="import" href="../../../../vaadin-valo-theme/icons.html">
+<link rel="import" href="../../../../vaadin-valo-styles/icons.html">
 
 <custom-style>
   <style include="valo-typography valo-color">

--- a/test/visual/vaadin-text-area/valo.html
+++ b/test/visual/vaadin-text-area/valo.html
@@ -2,7 +2,7 @@
 <script src="../../../../webcomponentsjs/webcomponents-loader.js"></script>
 <link href="../../../vaadin-text-area.html" rel="import">
 <link href="../../../../vaadin-button/vaadin-button.html" rel="import">
-<link rel="import" href="../../../../vaadin-valo-theme/icons.html">
+<link rel="import" href="../../../../vaadin-valo-styles/icons.html">
 
 <custom-style>
   <style include="valo-typography valo-color">

--- a/test/visual/vaadin-text-field/valo.html
+++ b/test/visual/vaadin-text-field/valo.html
@@ -2,7 +2,7 @@
 <script src="../../../../webcomponentsjs/webcomponents-loader.js"></script>
 <link href="../../../vaadin-text-field.html" rel="import">
 <link href="../../../../vaadin-button/vaadin-button.html" rel="import">
-<link rel="import" href="../../../../vaadin-valo-theme/icons.html">
+<link rel="import" href="../../../../vaadin-valo-styles/icons.html">
 
 <custom-style>
   <style include="valo-typography valo-color">

--- a/theme/valo/vaadin-password-field.html
+++ b/theme/valo/vaadin-password-field.html
@@ -16,8 +16,13 @@
       }
 
       /* Reduce the default width to accommodate the reveal button */
-      [part="value"] {
+      :host(:not([reveal-button-hidden])) [part="value"] {
         width: calc(10em - var(--valo-icon-size));
+      }
+
+      /* Make it easy to hide the button across the whole app */
+      [part="reveal-button"] {
+        display: var(--valo-password-field-reveal-button-display, block);
       }
     </style>
   </template>

--- a/theme/valo/vaadin-password-field.html
+++ b/theme/valo/vaadin-password-field.html
@@ -1,6 +1,6 @@
-<link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/mixins/field-button.html">
+<link rel="import" href="../../../vaadin-valo-styles/font-icons.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/mixins/field-button.html">
 
 <link rel="import" href="vaadin-text-field.html">
 

--- a/theme/valo/vaadin-text-area.html
+++ b/theme/valo/vaadin-text-area.html
@@ -1,5 +1,5 @@
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/typography.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/typography.html">
 
 <link rel="import" href="vaadin-text-field.html">
 

--- a/theme/valo/vaadin-text-field.html
+++ b/theme/valo/vaadin-text-field.html
@@ -1,8 +1,8 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/sizing.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
-<link rel="import" href="../../../vaadin-valo-theme/typography.html">
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
+<link rel="import" href="../../../vaadin-valo-styles/sizing.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/typography.html">
 
 <dom-module id="valo-text-field" theme-for="vaadin-text-field">
   <template>

--- a/theme/valo/vaadin-text-field.html
+++ b/theme/valo/vaadin-text-field.html
@@ -75,8 +75,7 @@
       [part="value"],
       [part="input-field"] ::slotted([part="value"]) {
         padding: 0 0.25em;
-        text-align: var(--valo-text-field-text-align);
-        --_valo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 24px);
+        --_valo-text-field-overflow-mask-image: linear-gradient(to left, transparent 0.25em, #000 1.5em);
         -webkit-mask-image: var(--_valo-text-field-overflow-mask-image);
         mask-image: var(--_valo-text-field-overflow-mask-image);
       }
@@ -115,6 +114,7 @@
         background-color: var(--valo-contrast-10pct);
         padding: 0 calc(0.375em + var(--valo-border-radius) / 4);
         font-weight: 500;
+        line-height: 1;
         position: relative;
         height: var(--valo-text-field-size);
         cursor: text;
@@ -139,7 +139,7 @@
 
       /* Hover */
 
-      :host(:hover:not([readonly])):not([focused])) [part="label"] {
+      :host(:hover:not([readonly]):not([focused])) [part="label"] {
         color: var(--valo-body-text-color);
       }
 
@@ -149,7 +149,7 @@
 
       /* Disable for touch devices */
       @media (pointer: coarse) {
-        :host(:hover:not([readonly])):not([focused])) [part="label"] {
+        :host(:hover:not([readonly]):not([focused])) [part="label"] {
           color: var(--valo-secondary-text-color);
         }
 
@@ -264,6 +264,25 @@
 
       :host([theme~="small"][label]) [part="error-message"] {
         font-size: var(--valo-font-size-xxs);
+      }
+
+      /* Text align */
+
+      :host([theme~="align-center"]) [part="value"] {
+        text-align: center;
+        --_valo-text-field-overflow-mask-image: none;
+      }
+
+      :host([theme~="align-right"]) [part="value"] {
+        text-align: right;
+        --_valo-text-field-overflow-mask-image: none;
+      }
+
+      @-moz-document url-prefix() {
+        /* Firefox is smart enough to align overflowing text to right */
+        :host([theme~="align-right"]) [part="value"] {
+          --_valo-text-field-overflow-mask-image: linear-gradient(to right, transparent 0.25em, #000 1.5em);
+        }
       }
 
       /* Slotted content */


### PR DESCRIPTION
### Examples

- Remove tabindex example (not a best practice)

- Remove data binding example (Polymer specific, not a text field
feature)

- Hide iron-form example (couldn’t get it to work). Can be added back
later if the binding scope is working

- Extract prefix and suffix examples (including icons) and RTL example
to separate pages

- Add a styling examples, which includes probably the most common
customizations (input field border and background)

- Extract all validation related examples into a separate page

- Remove “contrast” example from Valo theme examples

### Element themes

- Refactor text alignment to be a theme variation, not a CSS custom
property (allows other customizations that rely on this, such as the
mask image)

- Add a CSS custom property for hiding the password field reveal button

- Adjust the password field default width to match text field and text
area

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/179)
<!-- Reviewable:end -->
