### PR TITLE
Fix CSS specificity

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -62,6 +62,10 @@ This program is available under Apache License Version 2.0, available at https:/
         box-shadow: none;
       }
 
+      [part="input-field"] ::slotted(*) {
+        flex: none;
+      }
+
       /* Slotted by vaadin-dropdown-menu-text-field */
       [part="value"],
       [part="input-field"] ::slotted([part="value"]) {
@@ -75,10 +79,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
       [part="value"]::-ms-clear {
         display: none;
-      }
-
-      [part="input-field"] ::slotted(*) {
-        flex: none;
       }
     </style>
   </template>


### PR DESCRIPTION
Enable the slotted part=“value” to flex (fixes vaadin-dropdown-menu
styles).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/180)
<!-- Reviewable:end -->
