### PR TITLE
Make text-field min-width work like native input

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -31,7 +31,9 @@ This program is available under Apache License Version 2.0, available at https:/
       .vaadin-text-area-container {
         display: flex;
         flex-direction: column;
-        width: 100%;
+        min-width: 100%;
+        max-width: 100%;
+        width: var(--vaadin-text-field-default-width, 12em);
       }
 
       [part="label"]:empty {
@@ -72,8 +74,7 @@ This program is available under Apache License Version 2.0, available at https:/
         flex: auto;
         white-space: nowrap;
         overflow: hidden;
-        /* Really just min-width because of flex */
-        width: 10em;
+        width: 100%;
         height: 100%;
       }
 

--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -69,6 +69,12 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * ### Styling
        *
+       * The following custom properties are available for styling:
+       *
+       * Custom property | Description | Default
+       * ----------------|-------------|-------------
+       * `--vaadin-text-field-default-width` | Set the default width of the input field | `12em`
+       *
        * The following shadow DOM parts are available for styling:
        *
        * Part name | Description

--- a/theme/valo/vaadin-password-field.html
+++ b/theme/valo/vaadin-password-field.html
@@ -6,18 +6,13 @@
 
 <dom-module id="valo-password-field" theme-for="vaadin-password-field">
   <template>
-    <style include="valo-text-field valo-field-button">
+    <style include="valo-field-button">
       [part="reveal-button"]::before {
         content: var(--valo-icons-eye);
       }
 
       :host([password-visible]) [part="reveal-button"]::before {
         content: var(--valo-icons-eye-disabled);
-      }
-
-      /* Reduce the default width to accommodate the reveal button */
-      [part="value"] {
-        width: calc(10em - var(--valo-icon-size));
       }
     </style>
   </template>

--- a/theme/valo/vaadin-text-area.html
+++ b/theme/valo/vaadin-text-area.html
@@ -6,7 +6,6 @@
 <dom-module id="valo-text-area" theme-for="vaadin-text-area">
   <template>
     <style include="valo-text-field">
-
       [part="input-field"] {
         /* Equal to the implicit padding in vaadin-text-field */
         padding-top: calc((var(--valo-text-field-size) - var(--valo-icon-size)) / 2);


### PR DESCRIPTION
This solution works better than the previous one, as the developer can now control the min-width with the host element, and the prefix/suffix elements won’t grow the field width on top of that (they “eat into” the host width).

Add a new CSS custom property for setting the default width.

Remove unnecessary style module include from password-field (duplicate include).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/181)
<!-- Reviewable:end -->
