### PR TITLE
Fix vertical align guide element positioning

### DIFF
--- a/theme/valo/vaadin-text-field.html
+++ b/theme/valo/vaadin-text-field.html
@@ -19,9 +19,9 @@
 
       :host::before {
         height: var(--valo-text-field-size);
-        line-height: 1;
-        padding-top: calc((var(--valo-text-field-size) - 1em) / 2);
         box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
         /* input-field margin-top */
         margin-top: var(--valo-space-xs);
       }


### PR DESCRIPTION
The alignment could go off when the parent page is using a different font or line-height. Not setting the line-height to 1 fixes the issue (can be seen in the vaadin-date-picker “Using as a Form Field” demo).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/184)
<!-- Reviewable:end -->
