### PR TITLE
Fix native input placeholder alignment on ios

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -58,6 +58,7 @@ This program is available under Apache License Version 2.0, available at https:/
         min-width: 0;
         font: inherit;
         font-size: 1em;
+        line-height: normal;
         color: inherit;
         background-color: transparent;
         /* Disable default invalid style in Firefox */


### PR DESCRIPTION
If the line-height is not `normal`, the vertical align of the placeholder text is different from the actual value.