### PR TITLE
Fix text area activation effect

### DIFF
--- a/theme/valo/vaadin-text-area.html
+++ b/theme/valo/vaadin-text-area.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
 <link rel="import" href="../../../vaadin-valo-styles/sizing.html">
 <link rel="import" href="../../../vaadin-valo-styles/typography.html">
 
@@ -12,7 +13,25 @@
         padding-bottom: calc((var(--valo-text-field-size) - var(--valo-icon-size)) / 2);
         height: auto;
         box-sizing: border-box;
-        /* TODO how to make the ::after element not scroll with this container? */
+        transition: background-color 0.1s;
+      }
+
+      [part="input-field"]::after {
+        display: none;
+      }
+
+      :host(:hover:not([readonly]):not([focused])) [part="input-field"] {
+        background-color: var(--valo-contrast-20pct);
+      }
+
+      @media (pointer: coarse) {
+        :host(:hover:not([readonly]):not([focused])) [part="input-field"] {
+          background-color: var(--valo-contrast-10pct);
+        }
+
+        :host(:active:not([readonly]):not([focused])) [part="input-field"] {
+          background-color: var(--valo-contrast-20pct);
+        }
       }
 
       [part="value"] {


### PR DESCRIPTION
Since the pseudo element doesn’t scroll with the input field, we’ll just use a background-color transition for the hover/active effect.

The text-field transition can actually look too distracting on large text areas, so this is probably even a better design.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/188)
<!-- Reviewable:end -->
