### PR TITLE
Workaround mask-image CSS property to prevent crash in Edge

### DIFF
--- a/theme/valo/vaadin-text-field.html
+++ b/theme/valo/vaadin-text-field.html
@@ -77,12 +77,22 @@
         padding: 0 0.25em;
         --_valo-text-field-overflow-mask-image: linear-gradient(to left, transparent 0.25em, #000 1.5em);
         -webkit-mask-image: var(--_valo-text-field-overflow-mask-image);
-        mask-image: var(--_valo-text-field-overflow-mask-image);
       }
 
       [part="value"]:focus {
         -webkit-mask-image: none;
         mask-image: none;
+      }
+
+      /*
+        TODO: CSS custom property in `mask-image` causes crash in Edge
+        see https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15415089/
+      */
+      @-moz-document url-prefix() {
+        [part="value"],
+        [part="input-field"] ::slotted([part="value"]) {
+          mask-image: var(--_valo-text-field-overflow-mask-image);
+        }
       }
 
       [part="value"]::-webkit-input-placeholder {


### PR DESCRIPTION
Connected to vaadin/vaadin-valo-styles#45

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/189)
<!-- Reviewable:end -->
