### PR TITLE
Dispatch change event on native element change

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,11 +8,11 @@
       "sourceRange": {
         "file": "src/vaadin-text-area.html",
         "start": {
-          "line": 179,
+          "line": 180,
           "column": 6
         },
         "end": {
-          "line": 179,
+          "line": 180,
           "column": 42
         }
       },
@@ -117,11 +117,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -138,11 +138,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -160,11 +160,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -184,11 +184,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -205,11 +205,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -226,11 +226,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -247,11 +247,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -268,11 +268,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -289,11 +289,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -310,11 +310,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -335,11 +335,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -359,11 +359,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -380,11 +380,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 199,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 201,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -401,11 +401,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 203,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 205,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -420,11 +420,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 125,
+                  "line": 126,
                   "column": 12
                 },
                 "end": {
-                  "line": 127,
+                  "line": 128,
                   "column": 13
                 }
               },
@@ -439,11 +439,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 133,
+                  "line": 134,
                   "column": 12
                 },
                 "end": {
-                  "line": 135,
+                  "line": 136,
                   "column": 13
                 }
               },
@@ -458,11 +458,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 141,
+                  "line": 142,
                   "column": 12
                 },
                 "end": {
-                  "line": 143,
+                  "line": 144,
                   "column": 13
                 }
               },
@@ -477,11 +477,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 148,
+                  "line": 149,
                   "column": 12
                 },
                 "end": {
-                  "line": 150,
+                  "line": 151,
                   "column": 13
                 }
               },
@@ -498,12 +498,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 258,
-                  "column": 6
+                  "line": 271,
+                  "column": 4
                 },
                 "end": {
-                  "line": 267,
-                  "column": 7
+                  "line": 280,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -728,11 +728,34 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 213,
-                  "column": 6
+                  "column": 4
                 },
                 "end": {
                   "line": 220,
-                  "column": 7
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            },
+            {
+              "name": "_onChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-text-field-mixin.html",
+                "start": {
+                  "line": 222,
+                  "column": 4
+                },
+                "end": {
+                  "line": 233,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -750,12 +773,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 222,
-                  "column": 6
+                  "line": 235,
+                  "column": 4
                 },
                 "end": {
-                  "line": 235,
-                  "column": 7
+                  "line": 248,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -776,12 +799,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 237,
-                  "column": 6
+                  "line": 250,
+                  "column": 4
                 },
                 "end": {
-                  "line": 243,
-                  "column": 7
+                  "line": 256,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -799,12 +822,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 249,
-                  "column": 6
+                  "line": 262,
+                  "column": 4
                 },
                 "end": {
-                  "line": 255,
-                  "column": 7
+                  "line": 268,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -821,12 +844,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 275,
-                  "column": 6
+                  "line": 288,
+                  "column": 4
                 },
                 "end": {
-                  "line": 277,
-                  "column": 7
+                  "line": 290,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -844,12 +867,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 279,
-                  "column": 6
+                  "line": 292,
+                  "column": 4
                 },
                 "end": {
-                  "line": 281,
-                  "column": 7
+                  "line": 294,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -873,12 +896,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 283,
-                  "column": 6
+                  "line": 296,
+                  "column": 4
                 },
                 "end": {
-                  "line": 285,
-                  "column": 7
+                  "line": 298,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -899,12 +922,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 287,
-                  "column": 6
+                  "line": 300,
+                  "column": 4
                 },
                 "end": {
-                  "line": 289,
-                  "column": 7
+                  "line": 302,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -928,12 +951,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 294,
-                  "column": 6
+                  "line": 307,
+                  "column": 4
                 },
                 "end": {
-                  "line": 312,
-                  "column": 7
+                  "line": 325,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -985,11 +1008,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 106,
               "column": 6
             },
             "end": {
-              "line": 153,
+              "line": 154,
               "column": 7
             }
           },
@@ -1040,11 +1063,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1058,11 +1081,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1076,11 +1099,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1094,11 +1117,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1112,11 +1135,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1130,11 +1153,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1148,11 +1171,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1166,11 +1189,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1184,11 +1207,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1202,11 +1225,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1220,11 +1243,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1238,11 +1261,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -1254,11 +1277,11 @@
               "description": "This is a property supported by Safari that is used to control whether\nautocorrection should be enabled when the user is entering/editing the text.\nPossible values are:\non: Enable autocorrection.\noff: Disable autocorrection.",
               "sourceRange": {
                 "start": {
-                  "line": 125,
+                  "line": 126,
                   "column": 12
                 },
                 "end": {
-                  "line": 127,
+                  "line": 128,
                   "column": 13
                 }
               },
@@ -1270,11 +1293,11 @@
               "description": "Identifies a list of pre-defined options to suggest to the user.\nThe value must be the id of a <datalist> element in the same document.",
               "sourceRange": {
                 "start": {
-                  "line": 133,
+                  "line": 134,
                   "column": 12
                 },
                 "end": {
-                  "line": 135,
+                  "line": 136,
                   "column": 13
                 }
               },
@@ -1286,11 +1309,11 @@
               "description": "A regular expression that the value is checked against.\nThe pattern must match the entire value, not just some subset.",
               "sourceRange": {
                 "start": {
-                  "line": 141,
+                  "line": 142,
                   "column": 12
                 },
                 "end": {
-                  "line": 143,
+                  "line": 144,
                   "column": 13
                 }
               },
@@ -1302,11 +1325,11 @@
               "description": "Message to show to the user when validation fails.",
               "sourceRange": {
                 "start": {
-                  "line": 148,
+                  "line": 149,
                   "column": 12
                 },
                 "end": {
-                  "line": 150,
+                  "line": 151,
                   "column": 13
                 }
               },
@@ -1314,7 +1337,15 @@
               "type": "string"
             }
           ],
-          "events": [],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "change",
+              "description": "change",
+              "metadata": {},
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            }
+          ],
           "styling": {
             "cssVariables": [],
             "selectors": []
@@ -1341,11 +1372,11 @@
               "range": {
                 "file": "src/vaadin-text-field.html",
                 "start": {
-                  "line": 45,
+                  "line": 46,
                   "column": 8
                 },
                 "end": {
-                  "line": 45,
+                  "line": 46,
                   "column": 35
                 }
               }
@@ -1457,11 +1488,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1478,11 +1509,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1500,11 +1531,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1524,11 +1555,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1545,11 +1576,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1566,11 +1597,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1587,11 +1618,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1608,11 +1639,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1629,11 +1660,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1650,11 +1681,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1675,11 +1706,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1699,11 +1730,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1720,11 +1751,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 199,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 201,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1741,11 +1772,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 203,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 205,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -1761,11 +1792,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 125,
+                  "line": 126,
                   "column": 12
                 },
                 "end": {
-                  "line": 127,
+                  "line": 128,
                   "column": 13
                 }
               },
@@ -1782,11 +1813,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 133,
+                  "line": 134,
                   "column": 12
                 },
                 "end": {
-                  "line": 135,
+                  "line": 136,
                   "column": 13
                 }
               },
@@ -1803,11 +1834,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 141,
+                  "line": 142,
                   "column": 12
                 },
                 "end": {
-                  "line": 143,
+                  "line": 144,
                   "column": 13
                 }
               },
@@ -1824,11 +1855,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 148,
+                  "line": 149,
                   "column": 12
                 },
                 "end": {
-                  "line": 150,
+                  "line": 151,
                   "column": 13
                 }
               },
@@ -2117,11 +2148,34 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 213,
-                  "column": 6
+                  "column": 4
                 },
                 "end": {
                   "line": 220,
-                  "column": 7
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            },
+            {
+              "name": "_onChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-text-field-mixin.html",
+                "start": {
+                  "line": 222,
+                  "column": 4
+                },
+                "end": {
+                  "line": 233,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2139,12 +2193,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 222,
-                  "column": 6
+                  "line": 235,
+                  "column": 4
                 },
                 "end": {
-                  "line": 235,
-                  "column": 7
+                  "line": 248,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2165,12 +2219,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 237,
-                  "column": 6
+                  "line": 250,
+                  "column": 4
                 },
                 "end": {
-                  "line": 243,
-                  "column": 7
+                  "line": 256,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2188,12 +2242,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 249,
-                  "column": 6
+                  "line": 262,
+                  "column": 4
                 },
                 "end": {
-                  "line": 255,
-                  "column": 7
+                  "line": 268,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2210,12 +2264,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 275,
-                  "column": 6
+                  "line": 288,
+                  "column": 4
                 },
                 "end": {
-                  "line": 277,
-                  "column": 7
+                  "line": 290,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2233,12 +2287,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 279,
-                  "column": 6
+                  "line": 292,
+                  "column": 4
                 },
                 "end": {
-                  "line": 281,
-                  "column": 7
+                  "line": 294,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2262,12 +2316,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 283,
-                  "column": 6
+                  "line": 296,
+                  "column": 4
                 },
                 "end": {
-                  "line": 285,
-                  "column": 7
+                  "line": 298,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2288,12 +2342,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 287,
-                  "column": 6
+                  "line": 300,
+                  "column": 4
                 },
                 "end": {
-                  "line": 289,
-                  "column": 7
+                  "line": 302,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2317,12 +2371,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 294,
-                  "column": 6
+                  "line": 307,
+                  "column": 4
                 },
                 "end": {
-                  "line": 312,
-                  "column": 7
+                  "line": 325,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -2488,11 +2542,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2506,11 +2560,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2524,11 +2578,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2542,11 +2596,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2560,11 +2614,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2578,11 +2632,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2596,11 +2650,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2614,11 +2668,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2632,11 +2686,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2650,11 +2704,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2668,11 +2722,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2686,11 +2740,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -2703,11 +2757,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 125,
+                  "line": 126,
                   "column": 12
                 },
                 "end": {
-                  "line": 127,
+                  "line": 128,
                   "column": 13
                 }
               },
@@ -2721,11 +2775,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 133,
+                  "line": 134,
                   "column": 12
                 },
                 "end": {
-                  "line": 135,
+                  "line": 136,
                   "column": 13
                 }
               },
@@ -2739,11 +2793,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 141,
+                  "line": 142,
                   "column": 12
                 },
                 "end": {
-                  "line": 143,
+                  "line": 144,
                   "column": 13
                 }
               },
@@ -2757,11 +2811,11 @@
               "sourceRange": {
                 "file": "vaadin-text-field.html",
                 "start": {
-                  "line": 148,
+                  "line": 149,
                   "column": 12
                 },
                 "end": {
-                  "line": 150,
+                  "line": 151,
                   "column": 13
                 }
               },
@@ -2802,7 +2856,15 @@
               "type": "boolean"
             }
           ],
-          "events": [],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "change",
+              "description": "change",
+              "metadata": {},
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            }
+          ],
           "styling": {
             "cssVariables": [],
             "selectors": []
@@ -2910,11 +2972,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -2931,11 +2993,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -2953,11 +3015,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -2977,11 +3039,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -2998,11 +3060,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3019,11 +3081,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3040,11 +3102,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3061,11 +3123,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3082,11 +3144,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3103,11 +3165,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3128,11 +3190,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3152,11 +3214,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3173,11 +3235,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 199,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 201,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3194,11 +3256,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 203,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 205,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -3214,11 +3276,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 135,
+                  "line": 136,
                   "column": 8
                 },
                 "end": {
-                  "line": 138,
+                  "line": 139,
                   "column": 9
                 }
               },
@@ -3443,11 +3505,34 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 213,
-                  "column": 6
+                  "column": 4
                 },
                 "end": {
                   "line": 220,
-                  "column": 7
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            },
+            {
+              "name": "_onChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "vaadin-text-field-mixin.html",
+                "start": {
+                  "line": 222,
+                  "column": 4
+                },
+                "end": {
+                  "line": 233,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3465,12 +3550,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 222,
-                  "column": 6
+                  "line": 235,
+                  "column": 4
                 },
                 "end": {
-                  "line": 235,
-                  "column": 7
+                  "line": 248,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3491,12 +3576,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 237,
-                  "column": 6
+                  "line": 250,
+                  "column": 4
                 },
                 "end": {
-                  "line": 243,
-                  "column": 7
+                  "line": 256,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3514,12 +3599,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 249,
-                  "column": 6
+                  "line": 262,
+                  "column": 4
                 },
                 "end": {
-                  "line": 255,
-                  "column": 7
+                  "line": 268,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3536,12 +3621,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 275,
-                  "column": 6
+                  "line": 288,
+                  "column": 4
                 },
                 "end": {
-                  "line": 277,
-                  "column": 7
+                  "line": 290,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3559,12 +3644,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 279,
-                  "column": 6
+                  "line": 292,
+                  "column": 4
                 },
                 "end": {
-                  "line": 281,
-                  "column": 7
+                  "line": 294,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3588,12 +3673,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 283,
-                  "column": 6
+                  "line": 296,
+                  "column": 4
                 },
                 "end": {
-                  "line": 285,
-                  "column": 7
+                  "line": 298,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3614,12 +3699,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 287,
-                  "column": 6
+                  "line": 300,
+                  "column": 4
                 },
                 "end": {
-                  "line": 289,
-                  "column": 7
+                  "line": 302,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3643,12 +3728,12 @@
               "sourceRange": {
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
-                  "line": 294,
-                  "column": 6
+                  "line": 307,
+                  "column": 4
                 },
                 "end": {
-                  "line": 312,
-                  "column": 7
+                  "line": 325,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -3671,11 +3756,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 140,
+                  "line": 141,
                   "column": 8
                 },
                 "end": {
-                  "line": 142,
+                  "line": 143,
                   "column": 9
                 }
               },
@@ -3692,11 +3777,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 144,
+                  "line": 145,
                   "column": 8
                 },
                 "end": {
-                  "line": 171,
+                  "line": 172,
                   "column": 9
                 }
               },
@@ -3738,11 +3823,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 120,
+              "line": 121,
               "column": 6
             },
             "end": {
-              "line": 172,
+              "line": 173,
               "column": 7
             }
           },
@@ -3793,11 +3878,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3811,11 +3896,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3829,11 +3914,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3847,11 +3932,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3865,11 +3950,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3883,11 +3968,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3901,11 +3986,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3919,11 +4004,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3937,11 +4022,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3955,11 +4040,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3973,11 +4058,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -3991,11 +4076,11 @@
                 "file": "vaadin-text-field-mixin.html",
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -4003,7 +4088,15 @@
               "inheritedFrom": "Vaadin.TextFieldMixin"
             }
           ],
-          "events": [],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "change",
+              "description": "change",
+              "metadata": {},
+              "inheritedFrom": "Vaadin.TextFieldMixin"
+            }
+          ],
           "styling": {
             "cssVariables": [],
             "selectors": []
@@ -4030,11 +4123,11 @@
               "range": {
                 "file": "src/vaadin-text-area.html",
                 "start": {
-                  "line": 66,
+                  "line": 67,
                   "column": 8
                 },
                 "end": {
-                  "line": 66,
+                  "line": 67,
                   "column": 35
                 }
               }
@@ -4147,11 +4240,11 @@
               "sourceRange": {
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4166,11 +4259,11 @@
               "sourceRange": {
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4186,11 +4279,11 @@
               "sourceRange": {
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4208,11 +4301,11 @@
               "sourceRange": {
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4227,11 +4320,11 @@
               "sourceRange": {
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4246,11 +4339,11 @@
               "sourceRange": {
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4265,11 +4358,11 @@
               "sourceRange": {
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4284,11 +4377,11 @@
               "sourceRange": {
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4303,11 +4396,11 @@
               "sourceRange": {
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4322,11 +4415,11 @@
               "sourceRange": {
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4345,11 +4438,11 @@
               "sourceRange": {
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4367,11 +4460,11 @@
               "sourceRange": {
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4386,11 +4479,11 @@
               "sourceRange": {
                 "start": {
                   "line": 199,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 201,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4405,11 +4498,11 @@
               "sourceRange": {
                 "start": {
                   "line": 203,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 205,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {
@@ -4424,12 +4517,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 258,
-                  "column": 6
+                  "line": 271,
+                  "column": 4
                 },
                 "end": {
-                  "line": 267,
-                  "column": 7
+                  "line": 280,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4652,11 +4745,32 @@
               "sourceRange": {
                 "start": {
                   "line": 213,
-                  "column": 6
+                  "column": 4
                 },
                 "end": {
                   "line": 220,
-                  "column": 7
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "name": "_onChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 222,
+                  "column": 4
+                },
+                "end": {
+                  "line": 233,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4672,12 +4786,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 222,
-                  "column": 6
+                  "line": 235,
+                  "column": 4
                 },
                 "end": {
-                  "line": 235,
-                  "column": 7
+                  "line": 248,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4696,12 +4810,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 237,
-                  "column": 6
+                  "line": 250,
+                  "column": 4
                 },
                 "end": {
-                  "line": 243,
-                  "column": 7
+                  "line": 256,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4717,12 +4831,12 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 249,
-                  "column": 6
+                  "line": 262,
+                  "column": 4
                 },
                 "end": {
-                  "line": 255,
-                  "column": 7
+                  "line": 268,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4737,12 +4851,12 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 275,
-                  "column": 6
+                  "line": 288,
+                  "column": 4
                 },
                 "end": {
-                  "line": 277,
-                  "column": 7
+                  "line": 290,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4758,12 +4872,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 279,
-                  "column": 6
+                  "line": 292,
+                  "column": 4
                 },
                 "end": {
-                  "line": 281,
-                  "column": 7
+                  "line": 294,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4785,12 +4899,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 283,
-                  "column": 6
+                  "line": 296,
+                  "column": 4
                 },
                 "end": {
-                  "line": 285,
-                  "column": 7
+                  "line": 298,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4809,12 +4923,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 287,
-                  "column": 6
+                  "line": 300,
+                  "column": 4
                 },
                 "end": {
-                  "line": 289,
-                  "column": 7
+                  "line": 302,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4836,12 +4950,12 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 294,
-                  "column": 6
+                  "line": 307,
+                  "column": 4
                 },
                 "end": {
-                  "line": 312,
-                  "column": 7
+                  "line": 325,
+                  "column": 5
                 }
               },
               "metadata": {},
@@ -4864,11 +4978,11 @@
           "sourceRange": {
             "start": {
               "line": 96,
-              "column": 4
+              "column": 2
             },
             "end": {
-              "line": 313,
-              "column": 5
+              "line": 332,
+              "column": 3
             }
           },
           "privacy": "public",
@@ -4916,11 +5030,11 @@
               "sourceRange": {
                 "start": {
                   "line": 104,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 106,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -4932,11 +5046,11 @@
               "sourceRange": {
                 "start": {
                   "line": 111,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 114,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -4948,11 +5062,11 @@
               "sourceRange": {
                 "start": {
                   "line": 119,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 123,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -4964,11 +5078,11 @@
               "sourceRange": {
                 "start": {
                   "line": 128,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 130,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -4980,11 +5094,11 @@
               "sourceRange": {
                 "start": {
                   "line": 135,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 137,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -4996,11 +5110,11 @@
               "sourceRange": {
                 "start": {
                   "line": 142,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 144,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -5012,11 +5126,11 @@
               "sourceRange": {
                 "start": {
                   "line": 149,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 151,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -5028,11 +5142,11 @@
               "sourceRange": {
                 "start": {
                   "line": 156,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 159,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -5044,11 +5158,11 @@
               "sourceRange": {
                 "start": {
                   "line": 164,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 167,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -5060,11 +5174,11 @@
               "sourceRange": {
                 "start": {
                   "line": 174,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 179,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -5076,11 +5190,11 @@
               "sourceRange": {
                 "start": {
                   "line": 184,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 189,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
@@ -5092,18 +5206,25 @@
               "sourceRange": {
                 "start": {
                   "line": 195,
-                  "column": 10
+                  "column": 8
                 },
                 "end": {
                   "line": 197,
-                  "column": 11
+                  "column": 9
                 }
               },
               "metadata": {},
               "type": "boolean"
             }
           ],
-          "events": [],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "change",
+              "description": "change",
+              "metadata": {}
+            }
+          ],
           "styling": {
             "cssVariables": [],
             "selectors": []

--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -60,6 +60,7 @@ This program is available under Apache License Version 2.0, available at https:/
             value="{{value::input}}"
             on-blur="validate"
             on-input="_onInput"
+            on-change="_onChange"
             aria-describedby$="[[_getActiveErrorId(invalid, errorMessage, _errorId)]]"
             aria-labelledby$="[[_getActiveLabelId(label, _labelId)]]"
             aria-invalid$="[[invalid]]"></textarea>

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -220,6 +220,19 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    _onChange(e) {
+      // In the Shadow DOM, the `change` event is not leaked into the
+      // ancestor tree, so we must do this manually.
+      const changeEvent = new CustomEvent('change', {
+        detail: {
+          sourceEvent: e
+        },
+        bubbles: e.bubbles,
+        cancelable: e.cancelable,
+      });
+      this.dispatchEvent(changeEvent);
+    }
+
     _valueChanged(newVal, oldVal) {
       // setting initial value to empty string, skip validation
       if (newVal === '' && oldVal === undefined) {
@@ -311,5 +324,11 @@ This program is available under Apache License Version 2.0, available at https:/
         });
       }
     }
+
+    /**
+     * Fired when the user commits a value change.
+     *
+     * @event change
+     */
   };
 </script>

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -87,229 +87,229 @@ This program is available under Apache License Version 2.0, available at https:/
 </dom-module>
 
 <script>
-    window.Vaadin = window.Vaadin || {};
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @polymerMixin
+   * @memberof Vaadin
+   * @mixes Vaadin.ControlStateMixin
+   */
+  Vaadin.TextFieldMixin = subclass => class VaadinTextFieldMixin extends Vaadin.ControlStateMixin(subclass) {
+    static get properties() {
+      return {
+        /**
+         * Whether the value of the control can be automatically completed by the browser.
+         * List of available options at:
+         * https://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autocomplete
+         */
+        autocomplete: {
+          type: String
+        },
+
+        /**
+         * Error to show when the input value is invalid.
+         */
+        errorMessage: {
+          type: String,
+          value: ''
+        },
+
+        /**
+         * String used for the label element.
+         */
+        label: {
+          type: String,
+          value: '',
+          observer: '_labelChanged'
+        },
+
+        /**
+         * Maximum number of characters (in Unicode code points) that the user can enter.
+         */
+        maxlength: {
+          type: Number
+        },
+
+        /**
+         * Minimum number of characters (in Unicode code points) that the user can enter.
+         */
+        minlength: {
+          type: Number
+        },
+
+        /**
+         * The name of the control, which is submitted with the form data.
+         */
+        name: {
+          type: String
+        },
+
+        /**
+         * A hint to the user of what can be entered in the control.
+         */
+        placeholder: {
+          type: String
+        },
+
+        /**
+         * This attribute indicates that the user cannot modify the value of the control.
+         */
+        readonly: {
+          type: Boolean,
+          reflectToAttribute: true
+        },
+
+        /**
+         * Specifies that the user must fill in a value.
+         */
+        required: {
+          type: Boolean,
+          reflectToAttribute: true
+        },
+
+
+        /**
+         * The initial value of the control.
+         * It can be used for two-way data binding.
+         */
+        value: {
+          type: String,
+          value: '',
+          observer: '_valueChanged',
+          notify: true
+        },
+
+        /**
+         * This property is set to true when the control value is invalid.
+         */
+        invalid: {
+          type: Boolean,
+          reflectToAttribute: true,
+          notify: true,
+          value: false
+        },
+
+        /**
+         * When set to true, user is prevented from typing a value that
+         * conflicts with the given `pattern`.
+         */
+        preventInvalidInput: {
+          type: Boolean
+        },
+
+        _labelId: {
+          type: String
+        },
+
+        _errorId: {
+          type: String
+        }
+      };
+    }
+
+    get focusElement() {
+      return this.root.querySelector('[part=value]');
+    }
+
+    _onInput(e) {
+      if (this.preventInvalidInput) {
+        const input = this.focusElement;
+        if (input.value.length > 0 && !this.checkValidity()) {
+          input.value = this.value || '';
+        }
+      }
+    }
+
+    _valueChanged(newVal, oldVal) {
+      // setting initial value to empty string, skip validation
+      if (newVal === '' && oldVal === undefined) {
+        return;
+      }
+      if (this.invalid) {
+        this.validate();
+      }
+      if (newVal !== '' && newVal != null) {
+        this.setAttribute('has-value', '');
+      } else {
+        this.removeAttribute('has-value');
+      }
+    }
+
+    _labelChanged(label) {
+      if (label !== '' && label != null) {
+        this.setAttribute('has-label', '');
+      } else {
+        this.removeAttribute('has-label');
+      }
+    }
 
     /**
-     * @polymerMixin
-     * @memberof Vaadin
-     * @mixes Vaadin.ControlStateMixin
+     * Returns true if the current input value satisfies all constraints (if any)
+     * @returns {boolean}
      */
-    Vaadin.TextFieldMixin = subclass => class VaadinTextFieldMixin extends Vaadin.ControlStateMixin(subclass) {
-      static get properties() {
-        return {
-          /**
-           * Whether the value of the control can be automatically completed by the browser.
-           * List of available options at:
-           * https://developer.mozilla.org/en/docs/Web/HTML/Element/input#attr-autocomplete
-           */
-          autocomplete: {
-            type: String
-          },
-
-          /**
-           * Error to show when the input value is invalid.
-           */
-          errorMessage: {
-            type: String,
-            value: ''
-          },
-
-          /**
-           * String used for the label element.
-           */
-          label: {
-            type: String,
-            value: '',
-            observer: '_labelChanged'
-          },
-
-          /**
-           * Maximum number of characters (in Unicode code points) that the user can enter.
-           */
-          maxlength: {
-            type: Number
-          },
-
-          /**
-           * Minimum number of characters (in Unicode code points) that the user can enter.
-           */
-          minlength: {
-            type: Number
-          },
-
-          /**
-           * The name of the control, which is submitted with the form data.
-           */
-          name: {
-            type: String
-          },
-
-          /**
-           * A hint to the user of what can be entered in the control.
-           */
-          placeholder: {
-            type: String
-          },
-
-          /**
-           * This attribute indicates that the user cannot modify the value of the control.
-           */
-          readonly: {
-            type: Boolean,
-            reflectToAttribute: true
-          },
-
-          /**
-           * Specifies that the user must fill in a value.
-           */
-          required: {
-            type: Boolean,
-            reflectToAttribute: true
-          },
+    checkValidity() {
+      if (this.required || this.pattern || this.maxlength || this.minlength) {
+        return this.focusElement.checkValidity();
+      } else {
+        return !this.invalid;
+      }
+    }
 
 
-          /**
-           * The initial value of the control.
-           * It can be used for two-way data binding.
-           */
-          value: {
-            type: String,
-            value: '',
-            observer: '_valueChanged',
-            notify: true
-          },
-
-          /**
-           * This property is set to true when the control value is invalid.
-           */
-          invalid: {
-            type: Boolean,
-            reflectToAttribute: true,
-            notify: true,
-            value: false
-          },
-
-          /**
-           * When set to true, user is prevented from typing a value that
-           * conflicts with the given `pattern`.
-           */
-          preventInvalidInput: {
-            type: Boolean
-          },
-
-          _labelId: {
-            type: String
-          },
-
-          _errorId: {
-            type: String
-          }
-        };
+    ready() {
+      super.ready();
+      if (!(window.ShadyCSS && window.ShadyCSS.nativeCss)) {
+        this.updateStyles();
       }
 
-      get focusElement() {
-        return this.root.querySelector('[part=value]');
+      var uniqueId = Vaadin.TextFieldMixin._uniqueId = 1 + Vaadin.TextFieldMixin._uniqueId || 0;
+      this._errorId = `${this.constructor.is}-error-${uniqueId}`;
+      this._labelId = `${this.constructor.is}-label-${uniqueId}`;
+    }
+
+    /**
+     * Returns true if `value` is valid.
+     * `<iron-form>` uses this to check the validity or all its elements.
+     *
+     * @return {boolean} True if the value is valid.
+     */
+    validate() {
+      return !(this.invalid = !this.checkValidity());
+    }
+
+    _getActiveErrorId(invalid, errorMessage, errorId) {
+      return errorMessage && invalid ? errorId : undefined;
+    }
+
+    _getActiveLabelId(label, labelId) {
+      return label ? labelId : undefined;
+    }
+
+    _getErrorMessageAriaHidden(invalid, errorMessage, errorId) {
+      return (!this._getActiveErrorId(invalid, errorMessage, errorId)).toString();
+    }
+
+    /**
+     * @protected
+     */
+    attributeChangedCallback(prop, oldVal, newVal) {
+      super.attributeChangedCallback(prop, oldVal, newVal);
+      // Needed until Edge has CSS Custom Properties (present in Edge Preview)
+      if (!(window.ShadyCSS && window.ShadyCSS.nativeCss) &&
+        /^(focused|focus-ring|invalid|disabled|placeholder|has-value)$/.test(prop)) {
+        this.updateStyles();
       }
 
-      _onInput(e) {
-        if (this.preventInvalidInput) {
-          const input = this.focusElement;
-          if (input.value.length > 0 && !this.checkValidity()) {
-            input.value = this.value || '';
-          }
-        }
+      // Safari has an issue with repainting shadow root element styles when a host attribute changes.
+      // Need this workaround (toggle any inline css property on and off) until the issue gets fixed.
+      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+      if (isSafari && this.root) {
+        const WEBKIT_PROPERTY = '-webkit-backface-visibility';
+        this.root.querySelectorAll('*').forEach(el => {
+          el.style[WEBKIT_PROPERTY] = 'visible';
+          el.style[WEBKIT_PROPERTY] = '';
+        });
       }
-
-      _valueChanged(newVal, oldVal) {
-        // setting initial value to empty string, skip validation
-        if (newVal === '' && oldVal === undefined) {
-          return;
-        }
-        if (this.invalid) {
-          this.validate();
-        }
-        if (newVal !== '' && newVal != null) {
-          this.setAttribute('has-value', '');
-        } else {
-          this.removeAttribute('has-value');
-        }
-      }
-
-      _labelChanged(label) {
-        if (label !== '' && label != null) {
-          this.setAttribute('has-label', '');
-        } else {
-          this.removeAttribute('has-label');
-        }
-      }
-
-      /**
-       * Returns true if the current input value satisfies all constraints (if any)
-       * @returns {boolean}
-       */
-      checkValidity() {
-        if (this.required || this.pattern || this.maxlength || this.minlength) {
-          return this.focusElement.checkValidity();
-        } else {
-          return !this.invalid;
-        }
-      }
-
-
-      ready() {
-        super.ready();
-        if (!(window.ShadyCSS && window.ShadyCSS.nativeCss)) {
-          this.updateStyles();
-        }
-
-        var uniqueId = Vaadin.TextFieldMixin._uniqueId = 1 + Vaadin.TextFieldMixin._uniqueId || 0;
-        this._errorId = `${this.constructor.is}-error-${uniqueId}`;
-        this._labelId = `${this.constructor.is}-label-${uniqueId}`;
-      }
-
-      /**
-       * Returns true if `value` is valid.
-       * `<iron-form>` uses this to check the validity or all its elements.
-       *
-       * @return {boolean} True if the value is valid.
-       */
-      validate() {
-        return !(this.invalid = !this.checkValidity());
-      }
-
-      _getActiveErrorId(invalid, errorMessage, errorId) {
-        return errorMessage && invalid ? errorId : undefined;
-      }
-
-      _getActiveLabelId(label, labelId) {
-        return label ? labelId : undefined;
-      }
-
-      _getErrorMessageAriaHidden(invalid, errorMessage, errorId) {
-        return (!this._getActiveErrorId(invalid, errorMessage, errorId)).toString();
-      }
-
-      /**
-       * @protected
-       */
-      attributeChangedCallback(prop, oldVal, newVal) {
-        super.attributeChangedCallback(prop, oldVal, newVal);
-        // Needed until Edge has CSS Custom Properties (present in Edge Preview)
-        if (!(window.ShadyCSS && window.ShadyCSS.nativeCss) &&
-          /^(focused|focus-ring|invalid|disabled|placeholder|has-value)$/.test(prop)) {
-          this.updateStyles();
-        }
-
-        // Safari has an issue with repainting shadow root element styles when a host attribute changes.
-        // Need this workaround (toggle any inline css property on and off) until the issue gets fixed.
-        const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-        if (isSafari && this.root) {
-          const WEBKIT_PROPERTY = '-webkit-backface-visibility';
-          this.root.querySelectorAll('*').forEach(el => {
-            el.style[WEBKIT_PROPERTY] = 'visible';
-            el.style[WEBKIT_PROPERTY] = '';
-          });
-        }
-      }
-    };
-  </script>
+    }
+  };
+</script>

--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -38,6 +38,7 @@ This program is available under Apache License Version 2.0, available at https:/
           title="[[title]]"
           on-blur="validate"
           on-input="_onInput"
+          on-change="_onChange"
           aria-describedby$="[[_getActiveErrorId(invalid, errorMessage, _errorId)]]"
           aria-labelledby$="[[_getActiveLabelId(label, _labelId)]]"
           aria-invalid$="[[invalid]]"

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -147,7 +147,26 @@
           });
         });
       }
+    });
 
+    describe('events', function() {
+      let textField, input;
+
+      beforeEach(function() {
+        textField = fixture('default');
+        input = textField.focusElement;
+      });
+
+      it('should dispatch change event on native input change', done => {
+        const changeEvent = new Event('change');
+
+        textField.addEventListener('change', e => {
+          expect(e.detail.sourceEvent).to.equal(changeEvent);
+          done();
+        });
+
+        input.dispatchEvent(changeEvent);
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Fixes #195 

Note: the whole JS code of the mixin used to have bad indentation, so I fixed it in the first commit. Please ignore it, only the second commit is relevant for review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/197)
<!-- Reviewable:end -->
