### PR TITLE
Workaround IE11 placeholder issues

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -302,6 +302,10 @@ This program is available under Apache License Version 2.0, available at https:/
       var uniqueId = Vaadin.TextFieldMixin._uniqueId = 1 + Vaadin.TextFieldMixin._uniqueId || 0;
       this._errorId = `${this.constructor.is}-error-${uniqueId}`;
       this._labelId = `${this.constructor.is}-label-${uniqueId}`;
+
+      if (navigator.userAgent.match(/Trident/)) {
+        this._addIEListeners();
+      }
     }
 
     /**
@@ -312,6 +316,21 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     validate() {
       return !(this.invalid = !this.checkValidity());
+    }
+
+    _addIEListeners() {
+      // IE11 dispatches `input` event in following cases:
+      // - focus or blur, when placeholder attribute is set
+      // - placeholder attribute value changed
+      // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220/
+      const prevent = e => {
+        e.stopImmediatePropagation();
+        this.focusElement.removeEventListener('input', prevent);
+      };
+      const shouldPreventInput = () => this.placeholder && this.focusElement.addEventListener('input', prevent);
+      this.focusElement.addEventListener('focusin', shouldPreventInput);
+      this.focusElement.addEventListener('focusout', shouldPreventInput);
+      this._createPropertyObserver('placeholder', shouldPreventInput);
     }
 
     _getActiveErrorId(invalid, errorMessage, errorId) {

--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -30,7 +30,7 @@ This program is available under Apache License Version 2.0, available at https:/
           maxlength$="[[maxlength]]"
           minlength$="[[minlength]]"
           pattern="[[pattern]]"
-          placeholder="[[placeholder]]"
+          placeholder$="[[placeholder]]"
           readonly$="[[readonly]]"
           aria-readonly$="[[readonly]]"
           required$="[[required]]"

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -173,6 +173,56 @@
 
         input.dispatchEvent(changeEvent);
       });
+
+      // IE11 placeholder bug
+      const IE = navigator.userAgent.match(/Trident/);
+
+      (IE ? it : it.skip)('should not dispatch input event in IE on focus, when placeholder is set', done => {
+        const spy = sinon.spy();
+        textField.placeholder = 'foo';
+
+        textField.addEventListener('input', spy);
+
+        textField.focus();
+
+        setTimeout(() => {
+          expect(spy.called).to.be.false;
+          done();
+        });
+      });
+
+      (IE ? it : it.skip)('should not dispatch input event in IE on blur, when placeholder is set', done => {
+        const spy = sinon.spy();
+        textField.placeholder = 'foo';
+
+        textField.addEventListener('input', spy);
+
+        textField.focus();
+
+        // needs timeout to reproduce
+        setTimeout(() => {
+          textField.blur();
+
+          setTimeout(() => {
+            expect(spy.called).to.be.false;
+            done();
+          });
+        });
+      });
+
+      (IE ? it : it.skip)('should not dispatch input event in IE on placeholder value change', done => {
+        const spy = sinon.spy();
+        textField.placeholder = 'foo';
+
+        textField.addEventListener('input', spy);
+
+        textField.placeholder = 'bar';
+
+        setTimeout(() => {
+          expect(spy.called).to.be.false;
+          done();
+        });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Connected to vaadin/vaadin-date-picker#517

The link to the original [IE bug](https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220/).

@platosha I know you don't like flags but this time I really have no idea how to handle it better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/203)
<!-- Reviewable:end -->
