### PR TITLE
Replace input's and text-area's aria-labelledby attribute with aria-label

### DIFF
--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -64,7 +64,7 @@ This program is available under Apache License Version 2.0, available at https:/
             on-input="_onInput"
             on-change="_onChange"
             aria-describedby$="[[_getActiveErrorId(invalid, errorMessage, _errorId)]]"
-            aria-labelledby$="[[_getActiveLabelId(label, _labelId)]]"
+            aria-label$="[[label]]"
             aria-invalid$="[[invalid]]"></textarea>
 
         <slot name="suffix"></slot>

--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -40,7 +40,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <div class="vaadin-text-area-container">
 
-      <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
+      <label part="label" on-click="focus">[[label]]</label>
 
       <div part="input-field">
 

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -225,10 +225,6 @@ This program is available under Apache License Version 2.0, available at https:/
           type: Boolean
         },
 
-        _labelId: {
-          type: String
-        },
-
         _errorId: {
           type: String
         }
@@ -305,7 +301,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
       var uniqueId = Vaadin.TextFieldMixin._uniqueId = 1 + Vaadin.TextFieldMixin._uniqueId || 0;
       this._errorId = `${this.constructor.is}-error-${uniqueId}`;
-      this._labelId = `${this.constructor.is}-label-${uniqueId}`;
 
       /* istanbul ignore if */
       if (navigator.userAgent.match(/Trident/)) {

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -342,10 +342,6 @@ This program is available under Apache License Version 2.0, available at https:/
       return errorMessage && invalid ? errorId : undefined;
     }
 
-    _getActiveLabelId(label, labelId) {
-      return label ? labelId : undefined;
-    }
-
     _getErrorMessageAriaHidden(invalid, errorMessage, errorId) {
       return (!this._getActiveErrorId(invalid, errorMessage, errorId)).toString();
     }

--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -16,7 +16,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <div class="vaadin-text-field-container">
 
-      <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
+      <label part="label" on-click="focus">[[label]]</label>
 
       <div part="input-field">
 

--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -43,7 +43,7 @@ This program is available under Apache License Version 2.0, available at https:/
           on-input="_onInput"
           on-change="_onChange"
           aria-describedby$="[[_getActiveErrorId(invalid, errorMessage, _errorId)]]"
-          aria-labelledby$="[[_getActiveLabelId(label, _labelId)]]"
+          aria-label$="[[label]]"
           aria-invalid$="[[invalid]]"
         >
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -11,6 +11,7 @@
     "sinon": false,
     "HTMLImports": false,
     "MockInteractions": false,
+    "a11ySuite": false,
     "animationFrameFlush": false
   }
 }

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -68,21 +68,20 @@
       describe(`${el}: accessibility`, function() {
 
         describe('default', function() {
-          let tf, label, input;
+          let tf, input;
 
           beforeEach(function() {
             tf = fixture(`${el}-default`);
             input = tf.focusElement;
-            label = tf.root.querySelector('[part=label]');
           });
 
           it('should label the input', function() {
             tf.label = 'foo';
-            expect(input.getAttribute('aria-labelledby')).to.equal(label.id);
+            expect(input.getAttribute('aria-label')).to.equal(tf.label);
           });
 
           it('should not label the input', function() {
-            expect(input.hasAttribute('aria-labelledby')).to.be.false;
+            expect(input.getAttribute('aria-label')).to.equal('');
           });
 
           it('should not be marked required', function() {

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -9,6 +9,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../vaadin-text-field.html">
   <link rel="import" href="../vaadin-text-area.html">
+  <link rel="import" href="../../polymer/polymer.html">
 
 </head>
 
@@ -62,6 +63,20 @@
         <vaadin-text-area></vaadin-text-field>
       </template>
     </test-fixture>
+
+    <!-- MAGI REMOVE START -->
+    <test-fixture id="a11yTextField">
+      <template>
+        <vaadin-text-field label="foo"></vaadin-text-field>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="a11yTextArea">
+      <template>
+        <vaadin-text-area label="foo"></vaadin-text-area>
+      </template>
+    </test-fixture>
+    <!-- MAGI REMOVE END -->
 
   <script>
     ['vaadin-text-field', 'vaadin-text-area'].forEach(el => {
@@ -185,16 +200,14 @@
             expect(err0.id).not.to.equal(err1.id);
           });
 
-          it('should have unique label identifiers', function() {
-            var label0 = fields[0].root.querySelector('[part=label]');
-            var label1 = fields[1].root.querySelector('[part=label]');
-            expect(label0.id).not.to.equal(label1.id);
-          });
-
         });
 
       });
     });
 
+    /* MAGI REMOVE START */
+    a11ySuite('a11yTextField');
+    a11ySuite('a11yTextArea');
+    /* MAGI REMOVE END */
   </script>
 </body>


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-date-picker/issues/534

Element is failing a11y tests described in the original ticket. Disclaimer: I'm not expert on a11y related materials, but at least with this approach text-field tests and the a11y tests are both passing.

I did not add a11y tests to the test suite as I feel that should be done to vaadin-element-skeleton first (if added at all).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/252)
<!-- Reviewable:end -->
