### PR TITLE
Add text selection API

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -380,7 +380,6 @@ This program is available under Apache License Version 2.0, available at https:/
      *                            `"none"` if the direction is unknown or irrelevant.
      */
     setSelectionRange(start, end, direction) {
-      this.focus();
       this.focusElement.setSelectionRange(start, end, direction);
     }
 
@@ -392,18 +391,17 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /**
-     * Clear the selection from the input field.
+     * Clear the selection from the input field (collapse the selection to one of the edges of the current selection).
      *
      * @param {string} direction (Optional) A string indicating the direction in which the caret
      *                            should be placed. This string can be `"start"` or `"end"`. The
      *                            default is `"end"`.
      */
     clearSelection(direction) {
-      this.selectionEnd = 0;
       if (direction && direction == 'start') {
-        this.selectionStart = 0;
+        this.selectionEnd = this.selectionStart;
       } else {
-        this.selectionStart = this.value.length;
+        this.selectionStart = this.selectionEnd;
       }
     }
 

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -295,7 +295,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-
     ready() {
       super.ready();
       if (!(window.ShadyCSS && window.ShadyCSS.nativeCss)) {
@@ -369,6 +368,71 @@ This program is available under Apache License Version 2.0, available at https:/
           el.style[WEBKIT_PROPERTY] = '';
         });
       }
+    }
+
+    /**
+     * Select a specific range of text inside the input field.
+     *
+     * @param {number} start     The 0-based index of the first selected character
+     * @param {number} end       The 0-based index of the character after the last selected character
+     * @param {string} direction (Optional) A string indicating the direction in which the selection
+     *                            is performed. This string can be `"forward"` or `"backward"`, or
+     *                            `"none"` if the direction is unknown or irrelevant.
+     */
+    setSelectionRange(start, end, direction) {
+      this.focus();
+      this.focusElement.setSelectionRange(start, end, direction);
+    }
+
+    /**
+     * Select the text inside the input field.
+     */
+    selectAll() {
+      this.setSelectionRange(0, this.value.length);
+    }
+
+    /**
+     * Clear the selection from the input field.
+     *
+     * @param {string} direction (Optional) A string indicating the direction in which the caret
+     *                            should be placed. This string can be `"start"` or `"end"`. The
+     *                            default is `"end"`.
+     */
+    clearSelection(direction) {
+      this.selectionEnd = 0;
+      if (direction && direction == 'start') {
+        this.selectionStart = 0;
+      } else {
+        this.selectionStart = this.value.length;
+      }
+    }
+
+    /**
+     * Get or set the beginning of the selected portion of the field's text. Use in conjuction with
+     * the `selectionEnd` property. The value specifies the index of the first selected character.
+     * @returns {number}
+     */
+    get selectionStart() {
+      return this.focusElement.selectionStart;
+    }
+
+    set selectionStart(pos) {
+      this.focusElement.selectionStart = pos;
+    }
+
+    /**
+     * Get or set the end of the selected portion of the field's text. Use in conjuction with the
+     * `selectionStart` property. The value specifies the index of the character after the selection.
+     * If this value is equal to the value of the `selectionStart` property, no text is selected, but
+     * the value indicates the position of the caret (cursor) within the textbox.
+     * @returns {number}
+     */
+    get selectionEnd() {
+      return this.focusElement.selectionEnd;
+    }
+
+    set selectionEnd(pos) {
+      this.focusElement.selectionEnd = pos;
     }
 
     /**

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -85,6 +85,46 @@
             assertAttrCanBeSet(prop, false);
           });
         });
+
+        it('should set selection start', function() {
+          textField.value = "value";
+          textField.selectionStart = 2;
+          expect(input.selectionStart).to.be.equal(2);
+        });
+
+        it('should set selection end', function() {
+          textField.value = "value";
+          textField.selectionEnd = 4;
+          expect(input.selectionEnd).to.be.equal(4);
+        });
+
+        it('should set selection range', function() {
+          textField.value = "value";
+          textField.setSelectionRange(1, 3);
+          expect(input.selectionStart).to.be.equal(1);
+          expect(input.selectionEnd).to.be.equal(3);
+        });
+
+        it('should select all text', function() {
+          textField.value = "value";
+          textField.selectAll();
+          expect(textField.selectionStart).to.be.equal(0);
+          expect(textField.selectionEnd).to.be.equal(textField.value.length);
+        });
+
+        it('should clear text selection', function() {
+          textField.value = "value";
+
+          textField.setSelectionRange(1, 3);
+          textField.clearSelection();
+          expect(textField.selectionStart).to.be.equal(3);
+          expect(textField.selectionEnd).to.be.equal(3);
+
+          textField.setSelectionRange(1, 3);
+          textField.clearSelection('start');
+          expect(textField.selectionStart).to.be.equal(1);
+          expect(textField.selectionEnd).to.be.equal(1);
+        });
       });
 
       describe('binding', function() {

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -94,6 +94,9 @@
 
         it('should set selection end', function() {
           textField.value = 'value';
+          // Some browsers default the selection in an input element to the end of the value, so we
+          // move the selection start in order to be able to move the selection end
+          textField.selectionStart = 0;
           textField.selectionEnd = 4;
           expect(input.selectionEnd).to.be.equal(4);
         });

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -87,33 +87,33 @@
         });
 
         it('should set selection start', function() {
-          textField.value = "value";
+          textField.value = 'value';
           textField.selectionStart = 2;
           expect(input.selectionStart).to.be.equal(2);
         });
 
         it('should set selection end', function() {
-          textField.value = "value";
+          textField.value = 'value';
           textField.selectionEnd = 4;
           expect(input.selectionEnd).to.be.equal(4);
         });
 
         it('should set selection range', function() {
-          textField.value = "value";
+          textField.value = 'value';
           textField.setSelectionRange(1, 3);
           expect(input.selectionStart).to.be.equal(1);
           expect(input.selectionEnd).to.be.equal(3);
         });
 
         it('should select all text', function() {
-          textField.value = "value";
+          textField.value = 'value';
           textField.selectAll();
           expect(textField.selectionStart).to.be.equal(0);
           expect(textField.selectionEnd).to.be.equal(textField.value.length);
         });
 
         it('should clear text selection', function() {
-          textField.value = "value";
+          textField.value = 'value';
 
           textField.setSelectionRange(1, 3);
           textField.clearSelection();


### PR DESCRIPTION
Fixes #214 

No examples for these, as they are quite low-level APIs.

Didn’t know if we should add tests for these, as they mostly just forward the functionality to the native element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/258)
<!-- Reviewable:end -->
