### PR TITLE
Ignore ES6 demos in IE11 properly [skip ci]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "iron-test-helpers": "^2.0.0",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
-    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.1",
+    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.1.0",
     "vaadin-button": "vaadin/vaadin-button#^2.1.0"
   },
   "dependencies": {

--- a/demo/text-field-validators-demos.html
+++ b/demo/text-field-validators-demos.html
@@ -59,7 +59,7 @@
     <p>Extend <code>Vaadin.TextFieldElement</code> to create your own custom element,
       then override the <code>checkValidity()</code> method to validate the user’s input.</p>
 
-    <vaadin-demo-snippet id="text-field-validators-demos-synchronous-custom-validator">
+    <vaadin-demo-snippet id="text-field-validators-demos-synchronous-custom-validator" ignore-ie>
       <template preserve-content>
         <employee-role-text-field label="Position"></employee-role-text-field>
         Valid options: Architect, Developer or Designer
@@ -89,7 +89,7 @@
       then override the <code>checkValidity()</code> to make your asynchronous validation,
       and finally set the <code>invalid</code> flag appropriately in the callback.</p>
 
-    <vaadin-demo-snippet id="text-field-validators-demos-asynchronous-custom-validator">
+    <vaadin-demo-snippet id="text-field-validators-demos-asynchronous-custom-validator" ignore-ie>
       <template preserve-content>
         <my-ajax id="ajax1" handle-as="json" url="https://vaadin.com/validate-element"></my-ajax>
         <chemical-element-text-field label="Element Name"></chemical-element-text-field>
@@ -269,14 +269,6 @@
     class TextFieldValidatorsDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {
       static get is() {
         return 'text-field-validators-demos';
-      }
-
-      static get template() {
-        if (Array.prototype.find) {
-          return super.template;
-        } else {
-          return '<p>This demo must be viewed with an ES6 compatible browser</p>';
-        }
       }
     }
     customElements.define(TextFieldValidatorsDemos.is, TextFieldValidatorsDemos);


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#389

Depends on vaadin/vaadin-demo-helpers#55

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/259)
<!-- Reviewable:end -->
