### PR TITLE
Align prefix and suffix to center of text-area

### DIFF
--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -31,11 +31,6 @@ This program is available under Apache License Version 2.0, available at https:/
       [part="value"] {
         resize: none;
       }
-
-      [part="value"],
-      [part="input-field"] ::slotted(*) {
-        align-self: flex-start;
-      }
     </style>
 
     <div class="vaadin-text-area-container">

--- a/test/visual/common.html
+++ b/test/visual/common.html
@@ -1,12 +1,10 @@
 <dom-module id="text-field-styles" theme-for="vaadin-text-field vaadin-text-area">
   <template>
     <style>
-
       :host(.hidden-caret) [part="value"] {
         font-size: 0;
         height: 24px;
       }
-
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-text-field/issues/261

Requires changes from https://github.com/vaadin/vaadin-text-field/pull/248 and update visuals

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/262)
<!-- Reviewable:end -->
