### PR TITLE
Don't throw an error when focusing a newly created text-field

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -236,7 +236,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     get focusElement() {
-      return this.root.querySelector('[part=value]');
+      return this.root && this.root.querySelector('[part=value]');
     }
 
     _onInput(e) {

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -226,5 +226,12 @@
         });
       });
     });
+
+    describe('methods', function() {
+      it('should not throw an error when using focus() to a newly created element', () => {
+        // No expect needed as an error is thrown when focusing undefined element
+        document.createElement('vaadin-text-field').focus();
+      });
+    });
   </script>
 </body>


### PR DESCRIPTION
Connects to #269 

Requires first this to be merged and released: https://github.com/vaadin/vaadin-control-state-mixin/pull/47

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/270)
<!-- Reviewable:end -->
