### PR TITLE
Align Lumo imports for password-field and text-area

### DIFF
--- a/theme/lumo/vaadin-password-field-styles.html
+++ b/theme/lumo/vaadin-password-field-styles.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../../vaadin-lumo-styles/font-icons.html">
 <link rel="import" href="../../../vaadin-lumo-styles/sizing.html">
+<link rel="import" href="vaadin-text-field-styles.html">
 
 <dom-module id="lumo-password-field" theme-for="vaadin-password-field">
   <template>

--- a/theme/lumo/vaadin-password-field.html
+++ b/theme/lumo/vaadin-password-field.html
@@ -1,5 +1,2 @@
 <link rel="import" href="vaadin-password-field-styles.html">
-
-<link rel="import" href="vaadin-text-field.html">
 <link rel="import" href="../../src/vaadin-password-field.html">
-

--- a/theme/lumo/vaadin-text-area-styles.html
+++ b/theme/lumo/vaadin-text-area-styles.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../../vaadin-lumo-styles/color.html">
 <link rel="import" href="../../../vaadin-lumo-styles/sizing.html">
 <link rel="import" href="../../../vaadin-lumo-styles/typography.html">
+<link rel="import" href="vaadin-text-field-styles.html">
 
 <dom-module id="lumo-text-area" theme-for="vaadin-text-area">
   <template>

--- a/theme/lumo/vaadin-text-area.html
+++ b/theme/lumo/vaadin-text-area.html
@@ -1,3 +1,2 @@
 <link rel="import" href="vaadin-text-area-styles.html">
-<link rel="import" href="vaadin-text-field.html">
 <link rel="import" href="../../src/vaadin-text-area.html">


### PR DESCRIPTION
Currently, when importing `theme/lumo/vaadin-text-area.html`, you also get the `vaadin-text-field` component definition, although technically you might not need it. 

This change is unlikely to affect someone, as both components are still there in the same repo, and this structure is already implemented for Material.

In general, the users should import the components they are using explicitly, without relying on them being imported somewhere else (even in case of password-field extending text-field).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/287)
<!-- Reviewable:end -->
