### PR TITLE
Fix autoselect tests on iOS 9, add missing demo

### DIFF
--- a/demo/text-field-basic-demos.html
+++ b/demo/text-field-basic-demos.html
@@ -26,6 +26,13 @@
       </template>
     </vaadin-demo-snippet>
 
+    <h3>Autoselect</h3>
+    <vaadin-demo-snippet id="text-field-basic-demos-states">
+      <template preserve-content>
+        <vaadin-text-field label="Autoselect" value="Text selected on focus" autoselect></vaadin-text-field>
+      </template>
+    </vaadin-demo-snippet>
+
     <h3>Display the Clear Button</h3>
     <p>Use the <code>clear-button-visible</code> attribute to display the clear button of an individual text field.</p>
     <vaadin-demo-snippet id="text-field-basic-demos-clear-button">

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -531,6 +531,10 @@ This program is available under Apache License Version 2.0, available at https:/
     _onFocus() {
       if (this.autoselect) {
         this.focusElement.select();
+        // iOS 9 workaround: https://stackoverflow.com/a/7436574
+        setTimeout(() => {
+          this.focusElement.setSelectionRange(0, 9999);
+        });
       }
     }
 

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -222,17 +222,23 @@
             expect(textField.autoselect).to.be.false;
           });
 
-          it('should not select content on focus when autoselect is false', function() {
+          it('should not select content on focus when autoselect is false', function(done) {
             textField.value = '123';
             textField.focusElement.dispatchEvent(new CustomEvent('focus', {bubbles: false}));
-            expect(textField.focusElement.selectionEnd - textField.focusElement.selectionStart).to.equal(0);
+            setTimeout(() => {
+              expect(textField.focusElement.selectionEnd - textField.focusElement.selectionStart).to.equal(0);
+              done();
+            }, 1);
           });
 
-          it('should select content on focus when autoselect is true', function() {
+          it('should select content on focus when autoselect is true', function(done) {
             textField.value = '123';
             textField.autoselect = true;
             textField.focusElement.dispatchEvent(new CustomEvent('focus', {bubbles: false}));
-            expect(textField.focusElement.selectionEnd - textField.focusElement.selectionStart).to.equal(3);
+            setTimeout(() => {
+              expect(textField.focusElement.selectionEnd - textField.focusElement.selectionStart).to.equal(3);
+              done();
+            }, 1);
           });
         });
 


### PR DESCRIPTION
The tests for autoselect are broken on master, as we forgot to merge into branch and run push build before merging. This workaround fixes the regression.

Confirmed the need for `setTimeout` in simulator, it doesn't select the text without it.
See also [stackoverflow thread](https://stackoverflow.com/questions/3272089/programmatically-selecting-text-in-an-input-field-on-ios-devices-mobile-safari#comment60319255_6302507) where I actually found this workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/295)
<!-- Reviewable:end -->
