### PR TITLE
Don't flex-grow the input-field part of a text-field

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -46,6 +46,10 @@ This program is available under Apache License Version 2.0, available at https:/
         flex: auto;
       }
 
+      .vaadin-text-field-container [part="input-field"] {
+        flex-grow: 0;
+      }
+
       /* Reset the native input styles */
       [part="value"],
       [part="input-field"] ::slotted(input),

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -19,6 +19,14 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="wrapped">
+    <template>
+      <div>
+        <vaadin-text-field></vaadin-text-field>
+      </div>
+    </template>
+  </test-fixture>
+
   <test-fixture id="default-with-slotted-input">
     <template>
       <vaadin-text-field>
@@ -28,6 +36,25 @@
   </test-fixture>
 
   <script>
+
+    describe('Wrapped', () => {
+      var wrapper, textField, inputField;
+
+      beforeEach(() => {
+        wrapper = fixture('wrapped');
+        textField = wrapper.firstElementChild;
+        inputField = textField.shadowRoot.querySelector('[part=input-field]');
+      });
+
+      it('should not grow the input field inside a flex container', () => {
+        const fieldHeight = inputField.clientHeight;
+        wrapper.style.display = 'flex';
+        wrapper.style.height = '100px';
+        expect(inputField.clientHeight).to.equal(fieldHeight);
+      });
+
+    });
+
     ['', 'with slotted input'].forEach(condition => {
       let fixtureName = '';
       if (condition !== '') {


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-ordered-layout/issues/68

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/299)
<!-- Reviewable:end -->
