### PR TITLE
Prevent setting value over max and under min limit

### DIFF
--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -209,6 +209,12 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         __onInputChange() {
+          if (this.min && this.value < this.min) {
+            this.value = this.min;
+          } else if (this.max && this.value > this.max) {
+            this.value = this.max;
+          }
+
           this.checkValidity() && this.__adjustDecimals();
         }
 

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -246,6 +246,20 @@
           numberField.value = '5';
           expect(numberField.validate(), 'value should not be greater than max').to.be.false;
         });
+
+        it('should prevent setting value over max', () => {
+          numberField.max = 2;
+          numberField.value = 5;
+          numberField.focusElement.dispatchEvent(new Event('change'));
+          expect(numberField.value).to.be.equal('2');
+        });
+
+        it('should prevent setting value under min', () => {
+          numberField.min = 2;
+          numberField.value = 1;
+          numberField.focusElement.dispatchEvent(new Event('change'));
+          expect(numberField.value).to.be.equal('2');
+        });
       });
 
     });


### PR DESCRIPTION
Fixes "Typing 3, then 2 will result in invalid appearance for a number field with max of 31"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/304)
<!-- Reviewable:end -->
