### PR TITLE
fix: workaround slotted password field -ms-reveal [skip ci]

### DIFF
--- a/theme/lumo/vaadin-password-field-styles.html
+++ b/theme/lumo/vaadin-password-field-styles.html
@@ -16,6 +16,11 @@
       [part="reveal-button"] {
         display: var(--lumo-password-field-reveal-button-display, block);
       }
+
+      /* FIXME: ShadyCSS workaround for slotted input in Edge */
+      [part="input-field"] ::slotted(input)::-ms-reveal {
+        display: none;
+      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
Fixes #315 

Can be tested using following snippet:

```
  <vaadin-password-field>
    <input type="password" slot="input">
  </vaadin-password-field>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/316)
<!-- Reviewable:end -->
