### PR TITLE
Introduce inputElement getter

### DIFF
--- a/src/vaadin-email-field.html
+++ b/src/vaadin-email-field.html
@@ -39,8 +39,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
       ready() {
         super.ready();
-        this.focusElement.type = 'email';
-        this.focusElement.autocapitalize = 'off';
+        this.inputElement.type = 'email';
+        this.inputElement.autocapitalize = 'off';
         this.pattern = '^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$';
       }
     }

--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -131,8 +131,8 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
           this.__previousValidInput = this.value || '';
-          this.focusElement.type = 'number';
-          this.focusElement.addEventListener('change', this.__onInputChange.bind(this));
+          this.inputElement.type = 'number';
+          this.inputElement.addEventListener('change', this.__onInputChange.bind(this));
         }
 
         _decreaseButtonTouchend(e) {
@@ -203,7 +203,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _setValue(value) {
-          this.value = this.focusElement.value = value;
+          this.value = this.inputElement.value = value;
           this.dispatchEvent(new CustomEvent('change', {bubbles: true}));
         }
 
@@ -251,11 +251,11 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _minChanged() {
-          this.focusElement.min = this.min;
+          this.inputElement.min = this.min;
         }
 
         _maxChanged() {
-          this.focusElement.max = this.max;
+          this.inputElement.max = this.max;
         }
 
         _valueChanged(newVal, oldVal) {
@@ -277,11 +277,11 @@ This program is available under Apache License Version 2.0, available at https:/
 
         __adjustDecimals() {
           // when step is not an integer, adjust decimals.
-          this.focusElement.value && (this.value = parseFloat(this.focusElement.value).toFixed(this.__decimals));
+          this.inputElement.value && (this.value = parseFloat(this.inputElement.value).toFixed(this.__decimals));
         }
 
         _stepChanged(step) {
-          this.focusElement.step = step;
+          this.inputElement.step = step;
           // Compute number of dedimals to display in input based on provided step
           this.__decimals = String(step).replace(/^\d*\.?(.*)?$/, '$1').length;
           this.__adjustDecimals();
@@ -290,7 +290,7 @@ This program is available under Apache License Version 2.0, available at https:/
         checkValidity() {
           // text-field mixin does not check against `min` and `max`
           if (this.min !== undefined || this.max !== undefined) {
-            this.invalid = !this.focusElement.checkValidity();
+            this.invalid = !this.inputElement.checkValidity();
           }
           return super.checkValidity();
         }

--- a/src/vaadin-password-field.html
+++ b/src/vaadin-password-field.html
@@ -127,8 +127,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         ready() {
           super.ready();
-          this.focusElement.type = 'password';
-          this.focusElement.autocapitalize = 'off';
+          this.inputElement.type = 'password';
+          this.inputElement.autocapitalize = 'off';
 
           this.addEventListener('focusout', () => {
             if (!this._passwordVisibilityChanging) {
@@ -163,19 +163,19 @@ This program is available under Apache License Version 2.0, available at https:/
           // Cancel the following click event
           e.preventDefault();
           this._togglePasswordVisibility();
-          this.focusElement.focus();
+          this.inputElement.focus();
         }
 
         _togglePasswordVisibility() {
           this._passwordVisibilityChanging = true;
-          this.focusElement.blur();
+          this.inputElement.blur();
           this._setPasswordVisible(!this.passwordVisible);
-          this.focusElement.focus();
+          this.inputElement.focus();
           this._passwordVisibilityChanging = false;
         }
 
         _passwordVisibleChange(passwordVisible) {
-          this.focusElement.type = passwordVisible ? 'text' : 'password';
+          this.inputElement.type = passwordVisible ? 'text' : 'password';
         }
       }
 

--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -167,7 +167,7 @@ This program is available under Apache License Version 2.0, available at https:/
         _updateHeight() {
           const inputField = this.root.querySelector('[part=input-field]');
           const scrollTop = inputField.scrollTop;
-          const input = this.focusElement;
+          const input = this.inputElement;
 
           const inputWidth = getComputedStyle(input).width;
 

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -312,13 +312,20 @@ This program is available under Apache License Version 2.0, available at https:/
       return this.shadowRoot.querySelector('[part="value"]');
     }
 
+    /**
+     * @private
+     */
+    get inputElement() {
+      return this.focusElement;
+    }
+
     get _slottedTagName() {
       return 'input';
     }
 
     _onInput(e) {
       if (this.preventInvalidInput) {
-        const input = this.focusElement;
+        const input = this.inputElement;
         if (input.value.length > 0 && !this.checkValidity()) {
           input.value = this.value || '';
           // add input-prevented attribute for 200ms
@@ -382,9 +389,9 @@ This program is available under Apache License Version 2.0, available at https:/
         this.__userInput = false;
         return;
       } else if (newVal !== undefined) {
-        this.focusElement.value = newVal;
+        this.inputElement.value = newVal;
       } else {
-        this.value = this.focusElement.value = '';
+        this.value = this.inputElement.value = '';
       }
 
       if (this.invalid) {
@@ -404,7 +411,7 @@ This program is available under Apache License Version 2.0, available at https:/
       const slotted = this.querySelector(`${this._slottedTagName}[slot="${this._slottedTagName}"]`);
 
       if (this.value) {
-        this.focusElement.value = this.value;
+        this.inputElement.value = this.value;
         this.validate();
       }
 
@@ -439,7 +446,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _propagateHostAttributes(attributesValues, type) {
-      const input = this.focusElement;
+      const input = this.inputElement;
       const attributeNames = HOST_PROPS[type];
 
       if (type === 'accessible') {
@@ -474,7 +481,7 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     checkValidity() {
       if (this.required || this.pattern || this.maxlength || this.minlength) {
-        return this.focusElement.checkValidity();
+        return this.inputElement.checkValidity();
       } else {
         return !this.invalid;
       }
@@ -543,20 +550,20 @@ This program is available under Apache License Version 2.0, available at https:/
 
     _onFocus() {
       if (this.autoselect) {
-        this.focusElement.select();
+        this.inputElement.select();
         // iOS 9 workaround: https://stackoverflow.com/a/7436574
         setTimeout(() => {
-          this.focusElement.setSelectionRange(0, 9999);
+          this.inputElement.setSelectionRange(0, 9999);
         });
       }
     }
 
     _onClearButtonClick(e) {
       // NOTE(yuriy): This line won't affect focus on the host. Cannot be properly tested.
-      this.focusElement.focus();
+      this.inputElement.focus();
       this.clear();
       this._valueClearing = false;
-      this.focusElement.dispatchEvent(new Event('change', {bubbles: !this._slottedInput}));
+      this.inputElement.dispatchEvent(new Event('change', {bubbles: !this._slottedInput}));
     }
 
     _onKeyDown(e) {
@@ -574,7 +581,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220/
         this._prevent = e => {
           e.stopImmediatePropagation();
-          this.focusElement.removeEventListener('input', this._prevent);
+          this.inputElement.removeEventListener('input', this._prevent);
         };
         this._shouldPreventInput = () => this.placeholder && node.addEventListener('input', this._prevent);
         node.addEventListener('focusin', this._shouldPreventInput);
@@ -594,13 +601,13 @@ This program is available under Apache License Version 2.0, available at https:/
     _getActiveErrorId(invalid, errorMessage, errorId) {
       this._setOrToggleAttribute('aria-describedby',
         (errorMessage && invalid ? errorId : undefined),
-        this.focusElement);
+        this.inputElement);
     }
 
     _getActiveLabelId(label, labelId) {
       this._setOrToggleAttribute('aria-labelledby',
         (label ? labelId : undefined),
-        this.focusElement);
+        this.inputElement);
     }
 
     _getErrorMessageAriaHidden(invalid, errorMessage, errorId) {

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -177,7 +177,7 @@
 
             beforeEach(function() {
               tf = fixture(`${el}-default${fixtureName}`);
-              input = tf.focusElement;
+              input = tf.inputElement;
               label = tf.root.querySelector('[part=label]');
             });
 
@@ -215,7 +215,7 @@
 
             beforeEach(function() {
               tf = fixture(`${el}-error-fixture${fixtureName}`);
-              input = tf.focusElement;
+              input = tf.inputElement;
               err = tf.root.querySelector('[part=error-message]');
             });
 
@@ -260,7 +260,7 @@
             beforeEach(function() {
               tf = fixture(`${el}-invalid-fixture${fixtureName}`);
               err = tf.root.querySelector('[part=error-message]');
-              input = tf.focusElement;
+              input = tf.inputElement;
             });
 
             it('should show the error if initially invalid', function() {

--- a/test/custom-input.html
+++ b/test/custom-input.html
@@ -36,8 +36,8 @@
         input = textField.firstElementChild;
       });
 
-      it('should set focusElement to the slotted input', () => {
-        expect(textField.focusElement).to.equal(input);
+      it('should set inputElement to the slotted input', () => {
+        expect(textField.inputElement).to.equal(input);
       });
 
       it('should update value when slotted input value changes', () => {
@@ -87,9 +87,9 @@
         defaultInput = textField.shadowRoot.querySelector('[part~="value"]');
       });
 
-      it('should set focusElement to the default input', () => {
+      it('should set inputElement to the default input', () => {
         textField.removeChild(input);
-        expect(textField.focusElement).to.equal(defaultInput);
+        expect(textField.inputElement).to.equal(defaultInput);
       });
 
       it('should set value to the default input', () => {
@@ -127,9 +127,9 @@
         input.setAttribute('slot', 'input');
       });
 
-      it('should set focusElement to the slotted input', () => {
+      it('should set inputElement to the slotted input', () => {
         textField.appendChild(input);
-        expect(textField.focusElement).to.equal(input);
+        expect(textField.inputElement).to.equal(input);
       });
 
       it('should set value to the slotted input', () => {

--- a/test/email-field.html
+++ b/test/email-field.html
@@ -52,7 +52,7 @@
 
       beforeEach(() => {
         emailField = fixture('default');
-        input = emailField.focusElement;
+        input = emailField.inputElement;
       });
 
       it('should have [type=email]', () => {

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -23,7 +23,7 @@
 
       beforeEach(() => {
         numberField = fixture('default');
-        input = numberField.focusElement;
+        input = numberField.inputElement;
         decreaseButton = numberField.root.querySelector('[part=decrease-button]');
         increaseButton = numberField.root.querySelector('[part=increase-button]');
       });
@@ -258,7 +258,7 @@
           expect(numberField.validate()).to.be.true;
 
           numberField.value = '1';
-          expect(numberField.focusElement.value).to.be.equal('1');
+          expect(numberField.inputElement.value).to.be.equal('1');
           expect(numberField.validate()).to.be.true;
         });
 

--- a/test/password-field.html
+++ b/test/password-field.html
@@ -39,7 +39,7 @@
 
         beforeEach(function() {
           passwordField = fixture(`default${fixtureName}`);
-          input = passwordField.focusElement;
+          input = passwordField.inputElement;
           revealButton = passwordField.root.querySelector('[part=reveal-button]');
         });
 

--- a/test/text-area.html
+++ b/test/text-area.html
@@ -38,7 +38,7 @@
 
         beforeEach(() => {
           textArea = fixture(`default${fixtureName}`);
-          input = textArea.focusElement;
+          input = textArea.inputElement;
         });
 
         describe(`native ${condition}`, () => {
@@ -185,7 +185,7 @@
 
         beforeEach(() => {
           textArea = fixture(`default${fixtureName}`);
-          input = textArea.focusElement;
+          input = textArea.inputElement;
           inputField = textArea.shadowRoot.querySelector('[part=input-field]');
         });
 

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -100,7 +100,7 @@
 
         beforeEach(function() {
           textField = fixture(`default${fixtureName}`);
-          input = textField.focusElement;
+          input = textField.inputElement;
         });
 
         describe(`native ${condition}`, function() {
@@ -191,7 +191,7 @@
             expect(textField._valueClearing).to.be.true;
 
             // Emulates native change coming from input.
-            textField.focusElement.dispatchEvent(new Event('change', {bubbles: !condition}));
+            textField.inputElement.dispatchEvent(new Event('change', {bubbles: !condition}));
 
             textField.$.clearButton.dispatchEvent(new CustomEvent('click'));
             expect(textField._valueClearing).to.be.false;
@@ -233,7 +233,7 @@
           it('setting value to undefine should clear the native input value', function() {
             textField.value = 'foo';
             textField.value = undefined;
-            expect(textField.focusElement.value).to.equal('');
+            expect(textField.inputElement.value).to.equal('');
           });
 
           it('setting empty value does not update has-value attribute', function() {
@@ -291,9 +291,9 @@
 
           it('should not select content on focus when autoselect is false', function(done) {
             textField.value = '123';
-            textField.focusElement.dispatchEvent(new CustomEvent('focus', {bubbles: false}));
+            textField.inputElement.dispatchEvent(new CustomEvent('focus', {bubbles: false}));
             setTimeout(() => {
-              expect(textField.focusElement.selectionEnd - textField.focusElement.selectionStart).to.equal(0);
+              expect(textField.inputElement.selectionEnd - textField.inputElement.selectionStart).to.equal(0);
               done();
             }, 1);
           });
@@ -301,9 +301,9 @@
           it('should select content on focus when autoselect is true', function(done) {
             textField.value = '123';
             textField.autoselect = true;
-            textField.focusElement.dispatchEvent(new CustomEvent('focus', {bubbles: false}));
+            textField.inputElement.dispatchEvent(new CustomEvent('focus', {bubbles: false}));
             setTimeout(() => {
-              expect(textField.focusElement.selectionEnd - textField.focusElement.selectionStart).to.equal(3);
+              expect(textField.inputElement.selectionEnd - textField.inputElement.selectionStart).to.equal(3);
               done();
             }, 1);
           });
@@ -316,7 +316,7 @@
 
         beforeEach(function() {
           textField = fixture(`default${fixtureName}`);
-          input = textField.focusElement;
+          input = textField.inputElement;
         });
 
         it('should dispatch change event on native input change', done => {

--- a/test/validation.html
+++ b/test/validation.html
@@ -76,7 +76,7 @@
           beforeEach(function() {
             iform = fixture(`${el}-default${fixtureName}`);
             tf = iform.querySelector(el);
-            input = tf.focusElement;
+            input = tf.inputElement;
           });
 
           it('should call validate', function(done) {


### PR DESCRIPTION
Connects to https://github.com/vaadin/vaadin-select/issues/182
Required by https://github.com/vaadin/vaadin-select/pull/183

As in `vaadin-select` example `inputElement` and `focusElement` are not always the same, so new `inputElement` getter is introduced in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/317)
<!-- Reviewable:end -->
