### PR TITLE
Simplify input event prevention

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -324,6 +324,12 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onInput(e) {
+      if (this.__preventInput) {
+        e.stopImmediatePropagation();
+        this.__preventInput = false;
+        return;
+      }
+
       if (this.preventInvalidInput) {
         const input = this.inputElement;
         if (input.value.length > 0 && !this.checkValidity()) {
@@ -583,11 +589,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // - focus or blur, when placeholder attribute is set
         // - placeholder attribute value changed
         // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101220/
-        this._prevent = e => {
-          e.stopImmediatePropagation();
-          this.inputElement.removeEventListener('input', this._prevent);
-        };
-        this._shouldPreventInput = () => this.placeholder && node.addEventListener('input', this._prevent);
+        this._shouldPreventInput = () => this.__preventInput = true;
         node.addEventListener('focusin', this._shouldPreventInput);
         node.addEventListener('focusout', this._shouldPreventInput);
         this._createPropertyObserver('placeholder', this._shouldPreventInput);


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-date-picker/issues/634

There was a minor timing issue with preventing `input` event occurring on `focusin` which leads to the problem with https://github.com/vaadin/vaadin-date-picker/issues/634 .
The solution is still covered with the tests, however the timing is difficult to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/326)
<!-- Reviewable:end -->
