### PR TITLE
fix: replace lumo leftovers in number-field material

### DIFF
--- a/theme/material/vaadin-number-field-styles.html
+++ b/theme/material/vaadin-number-field-styles.html
@@ -2,9 +2,9 @@
 <link rel="import" href="../../../vaadin-material-styles/font-icons.html">
 <link rel="import" href="../../../vaadin-material-styles/mixins/field-button.html">
 
-<dom-module id="lumo-number-field" theme-for="vaadin-number-field">
+<dom-module id="material-number-field" theme-for="vaadin-number-field">
   <template>
-    <style include="lumo-field-button">
+    <style include="material-field-button">
       :host {
         width: 8em;
       }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/327)
<!-- Reviewable:end -->
