### PR TITLE
Improve slotted selector for ff47

### DIFF
--- a/theme/material/vaadin-text-field-styles.html
+++ b/theme/material/vaadin-text-field-styles.html
@@ -215,7 +215,7 @@
 
       /* Slotted content */
 
-      [part="input-field"] ::slotted(*:not([part="value"]):not(input):not(textarea)) {
+      [part="input-field"] ::slotted(*:not([part="value"]):not([part$="-button"]):not(input):not(textarea)) {
         color: var(--material-secondary-text-color);
       }
 


### PR DESCRIPTION
Improve slotted selector for Firefox 47 which is used in visual tests.
This issue causing problems with visual tests in `datepicker` on master.
Related to https://github.com/vaadin/vaadin-date-picker/pull/637

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/337)
<!-- Reviewable:end -->
