### PR TITLE
Add a "label-suffix" slot

### DIFF
--- a/demo/demos.json
+++ b/demo/demos.json
@@ -100,6 +100,16 @@
         "description": "",
         "image": ""
       }
+    },
+    {
+      "name": "Label",
+      "url": "text-field-label-demos",
+      "src": "text-field-label-demos.html",
+      "meta": {
+        "title": "Vaadin Text Field Label Examples",
+        "description": "",
+        "image": ""
+      }
     }
   ]
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -20,6 +20,7 @@
   <link rel="import" href="../vaadin-number-field.html">
   <link rel="import" href="../../iron-form/iron-form.html">
   <link rel="import" href="../../vaadin-lumo-styles/icons.html">
+  <link rel="import" href="../../vaadin-button/vaadin-button.html">
 
   <!-- Used in the styling examples, keep in sync -->
   <dom-module id="my-text-field-styles" theme-for="vaadin-text-field vaadin-text-area">

--- a/demo/text-field-label-demos.html
+++ b/demo/text-field-label-demos.html
@@ -1,0 +1,39 @@
+<dom-module id="text-field-label-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+
+    <h3>Label suffix</h3>
+    <vaadin-demo-snippet id="text-field-label-demos-label-suffix">
+      <template preserve-content>
+        <vaadin-password-field id="password" label="New password">
+          <vaadin-button id="suggest" slot="label-suffix" theme="tertiary-inline">suggest</vaadin-button>
+        </vaadin-password-field>
+        <script>
+          window.addDemoReadyListener('#text-field-label-demos-label-suffix', function(document) {
+            const field = document.getElementById('password');
+            const button = document.getElementById('suggest');
+            button.addEventListener('click', function(event) {
+              field.value = Math.random().toString(36).substring(7);
+              field._setPasswordVisible(true);
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+
+  </template>
+  <script>
+    class TextFieldLabelDemos extends DemoReadyEventEmitter(TextFieldDemo(Polymer.Element)) {
+      static get is() {
+        return 'text-field-label-demos';
+      }
+    }
+    customElements.define(TextFieldLabelDemos.is, TextFieldLabelDemos);
+  </script>
+</dom-module>

--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -50,7 +50,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <div class="vaadin-text-area-container">
 
-      <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
+      <div part="label-container">
+        <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
+        <div part="label-suffix"><slot name="label-suffix"></slot></div>
+      </div>
 
       <div part="input-field">
 

--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -16,7 +16,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
     <div class="vaadin-text-field-container">
 
-      <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
+      <div part="label-container">
+        <label part="label" on-click="focus" id="[[_labelId]]">[[label]]</label>
+        <div part="label-suffix"><slot name="label-suffix"></slot></div>
+      </div>
 
       <div part="input-field">
 

--- a/theme/lumo/vaadin-text-field-styles.html
+++ b/theme/lumo/vaadin-text-field-styles.html
@@ -28,6 +28,13 @@
         align-items: center;
       }
 
+      [part="label-container"] {
+        display: flex;
+        justify-content: space-between;
+        line-height: 1;
+        font-size: var(--lumo-font-size-s);
+      }
+
       :host([focused]:not([readonly])) [part="label"] {
         color: var(--lumo-primary-text-color);
       }


### PR DESCRIPTION
This is my second attempt to fix #212 (the first was #213); it is cleaner and can easily be applied to other components porting the style to a mixin in `lumo-styles`.

As for your previous @tomivirkki considerations:

- this is a small breaking change, so I do not expect it to be merged before 3.0
- this would not affect the Material theme, so it would be a feature of Lumo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/367)
<!-- Reviewable:end -->
