### PR TITLE
fix: make it possible to detect clear button as the source for input …

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -365,19 +365,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
-      if (this.__inputFromClearButton) {
-        this.__inputFromClearButton = false;
-        // In this case when input event is triggered by clear button we need to skip
-        // setting "this.__userInput = true" because the clear button clears the value
-        // first triggering _valueChanged() before this input event. If we wouldn't
-        // skip this, then __userInput would be left true until the next _valueChanged()
-        // happens which would then prevent setting this.inputElement.value correctly
-        // leaving it out of sync with this.value.
-      } else {
-        // This is used to prevent setting this.inputElement.value in _valueChanged()
-        // when this input event was actually triggered by the user from the input
-        // element itself (thus the value there should be correct already).
-        // This flag is set back to false in _valueChanged().
+      if (!e.__fromClearButton) {
         this.__userInput = true;
       }
       this.value = e.target.value;
@@ -612,9 +600,12 @@ This program is available under Apache License Version 2.0, available at https:/
         // below to propagate normally.
         this.__preventInput = false;
       }
-      this.__inputFromClearButton = true;
-      this.inputElement.dispatchEvent(new Event('input', {bubbles: true, composed: true}));
-      this.inputElement.dispatchEvent(new Event('change', {bubbles: !this._slottedInput}));
+      const inputEvent = new Event('input', {bubbles: true, composed: true});
+      inputEvent.__fromClearButton = true;
+      const changeEvent = new Event('change', {bubbles: !this._slottedInput});
+      changeEvent.__fromClearButton = true;
+      this.inputElement.dispatchEvent(inputEvent);
+      this.inputElement.dispatchEvent(changeEvent);
     }
 
     _onKeyDown(e) {


### PR DESCRIPTION
…and change events

Add property `__fromClearButton = true` (private API for now) to the `input` and `change` events sent by the clear button.

Fixes #368 and unblocks vaadin/vaadin-combo-box#805.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/369)
<!-- Reviewable:end -->
