### PR TITLE
fix(number-field): reflect to attribute properly

### DIFF
--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -102,7 +102,7 @@ This program is available under Apache License Version 2.0, available at https:/
             */
             min: {
               type: Number,
-              reflectToAttribue: true
+              reflectToAttribute: true
             },
 
             /**
@@ -110,7 +110,7 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             max: {
               type: Number,
-              reflectToAttribue: true,
+              reflectToAttribute: true,
               observer: '_maxChanged'
             },
 
@@ -119,7 +119,7 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             step: {
               type: Number,
-              reflectToAttribue: true,
+              reflectToAttribute: true,
               value: 1
             }
 

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -37,6 +37,16 @@
         increaseButton = numberField.root.querySelector('[part=increase-button]');
       });
 
+      describe('properties', () => {
+        ['min', 'max', 'step'].forEach(prop => {
+          it(`should reflect "${prop}" property to attribute`, () => {
+            var value = 5;
+            numberField[prop] = value;
+            expect(numberField.getAttribute(prop)).to.be.equal(String(value));
+          });
+        });
+      });
+
       describe('native', () => {
 
         it('should have [type=number]', () => {
@@ -528,7 +538,7 @@
             expect(numberField.value).to.be.equal('19');
           });
 
-          it(`should set value to the first step value above zero when min is below zero 
+          it(`should set value to the first step value above zero when min is below zero
               and max is above zero and increaseButton is clicked`, () => {
             numberField.min = -19;
             numberField.max = 19;
@@ -569,7 +579,7 @@
             expect(numberField.value).to.be.equal('-3');
           });
 
-          it(`should set value to the first step value below zero when min is below zero and max 
+          it(`should set value to the first step value below zero when min is below zero and max
               is above zero and decreaseButton is clicked`, () => {
             numberField.min = -19;
             numberField.max = 19;


### PR DESCRIPTION
Found a typo which has been unnoticed for a while 🙈 

Not sure if we actually need these to be reflected to attributes. Maybe we could just remove these lines, as it has never worked, and nobody has any complaint 🤔

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/384)
<!-- Reviewable:end -->
