### PR TITLE
Move readonly state border from pseudo element to input-field part

### DIFF
--- a/theme/lumo/vaadin-text-field-styles.html
+++ b/theme/lumo/vaadin-text-field-styles.html
@@ -38,8 +38,8 @@
       /* Slotted by vaadin-select-text-field */
       [part="input-field"] ::slotted([part="value"]) {
         cursor: inherit;
-        min-height: var(--lumo-text-field-size);
-        padding: 0 0.25em;
+        min-height: calc(var(--lumo-text-field-size) - 2px);
+        padding: 0 calc(0.25em - 1px);
         --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
         -webkit-mask-image: var(--_lumo-text-field-overflow-mask-image);
       }
@@ -90,7 +90,7 @@
       [part="input-field"] {
         border-radius: var(--lumo-border-radius);
         background-color: var(--lumo-contrast-10pct);
-        padding: 0 calc(0.375em + var(--lumo-border-radius) / 4 - 1px);
+        padding: 1px calc(0.375em + var(--lumo-border-radius) / 4);
         font-weight: 500;
         line-height: 1;
         position: relative;
@@ -180,10 +180,9 @@
         cursor: default;
       }
 
-      :host([readonly]) [part="input-field"]::after {
-        background-color: transparent;
-        opacity: 1;
+      :host([readonly]) [part="input-field"] {
         border: 1px dashed var(--lumo-contrast-30pct);
+        padding: 0 calc(0.375em + var(--lumo-border-radius) / 4 - 1px);
       }
 
       /* Disabled style */


### PR DESCRIPTION
Fixes #228

This is one way to fix the issue. It’s not really pretty (more `calc()`s, not really DRY), but it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-text-field/394)
<!-- Reviewable:end -->
