### PR TITLE
fix: Suppress error on autoselect workaround

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -593,7 +593,12 @@ This program is available under Apache License Version 2.0, available at https:/
         this.inputElement.select();
         // iOS 9 workaround: https://stackoverflow.com/a/7436574
         setTimeout(() => {
-          this.inputElement.setSelectionRange(0, 9999);
+          try {
+            this.inputElement.setSelectionRange(0, 9999);
+          } catch (e) {
+            // The workaround may cause errors on different input types.
+            // Needs to be suppressed. See https://github.com/vaadin/flow/issues/6070
+          }
         });
       }
     }

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -45,6 +45,12 @@
             expect(numberField.getAttribute(prop)).to.be.equal(String(value));
           });
         });
+
+        it('should not throw with autoselect', done => {
+          numberField.autoselect = true;
+          numberField.focus();
+          setTimeout(done);
+        });
       });
 
       describe('native', () => {


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/6070

Fixing the issue with try -> catch feels a bit unclean. Another approach would be to check the type of the input, but then we'd need to include a list of arbitrary input types that do support `setSelectionRange`.