### PR TITLE
fix: duplicate value-changed events from number-field buttons

### DIFF
--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -232,7 +232,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _setValue(value) {
-          this.value = this.inputElement.value = parseFloat(value);
+          this.value = this.inputElement.value = String(parseFloat(value));
           this.dispatchEvent(new CustomEvent('change', {bubbles: true}));
         }
 

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -133,6 +133,18 @@
 
           increaseButton.click();
           expect(changeSpy.callCount).to.equal(1);
+          decreaseButton.click();
+          expect(changeSpy.callCount).to.equal(2);
+        });
+
+        it('should dispatch single value-changed event when button is clicked', () => {
+          const spy = sinon.spy();
+          numberField.addEventListener('value-changed', spy);
+
+          increaseButton.click();
+          expect(spy.callCount).to.equal(1);
+          decreaseButton.click();
+          expect(spy.callCount).to.equal(2);
         });
 
         it('should not focus input when a button is clicked', () => {


### PR DESCRIPTION
Setting a number value causes the component to convert it to string and
thus change the value another time.

fix #413