### PR TITLE
docs: fix title-property JSDoc [skip ci]

### DIFF
--- a/src/vaadin-text-field.html
+++ b/src/vaadin-text-field.html
@@ -130,7 +130,7 @@ This program is available under Apache License Version 2.0, available at https:/
             },
 
             /**
-             * Message to show to the user when validation fails.
+             * The text usually displayed in a tooltip popup when the mouse is over the field.
              */
             title: {
               type: String


### PR DESCRIPTION
based on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title

fix #293