### PR TITLE
fix: avoid using initial step in validation

### DIFF
--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -120,7 +120,6 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             step: {
               type: Number,
-              reflectToAttribute: true,
               value: 1,
               observer: '_stepChanged'
             }
@@ -303,13 +302,13 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _stepChanged(step) {
-          if (!this.__stepChangedCalled && step === 1) {
-            // Setting the initial value, avoid using it in validation.
-            this.inputElement.step = 'any';
-          } else {
-            this.inputElement.step = step;
-          }
+          // Avoid using initial value in validation
+          const validateByStep = this.__stepChangedCalled
+            || (!this.__stepChangedCalled && this.getAttribute('step') !== null);
+          this.inputElement.step = validateByStep ? step : 'any';
+
           this.__stepChangedCalled = true;
+          this.setAttribute('step', step);
         }
 
         _minChanged(min) {
@@ -348,7 +347,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         checkValidity() {
           // text-field mixin does not check against `min`, `max` and `step`
-          if (this.min !== undefined || this.max !== undefined || this.step !== 1) {
+          if (this.min !== undefined || this.max !== undefined || this.inputElement.step !== 'any') {
             this.invalid = !this.inputElement.checkValidity();
           }
           return super.checkValidity();

--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -303,9 +303,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _stepChanged(step) {
           // Avoid using initial value in validation
-          const validateByStep = this.__stepChangedCalled
+          this.__validateByStep = this.__stepChangedCalled
             || (!this.__stepChangedCalled && this.getAttribute('step') !== null);
-          this.inputElement.step = validateByStep ? step : 'any';
+          this.inputElement.step = this.__validateByStep ? step : 'any';
 
           this.__stepChangedCalled = true;
           this.setAttribute('step', step);
@@ -347,7 +347,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         checkValidity() {
           // text-field mixin does not check against `min`, `max` and `step`
-          if (this.min !== undefined || this.max !== undefined || this.inputElement.step !== 'any') {
+          if (this.min !== undefined || this.max !== undefined || this.__validateByStep) {
             this.invalid = !this.inputElement.checkValidity();
           }
           return super.checkValidity();

--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -303,7 +303,13 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _stepChanged(step) {
-          this.inputElement.step = step;
+          if (!this.__stepChangedCalled) {
+            // Setting the initial value, avoid using it in validation.
+            this.inputElement.step = 'any';
+            this.__stepChangedCalled = true;
+          } else {
+            this.inputElement.step = step;
+          }
         }
 
         _minChanged(min) {

--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -303,13 +303,13 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _stepChanged(step) {
-          if (!this.__stepChangedCalled) {
+          if (!this.__stepChangedCalled && step === 1) {
             // Setting the initial value, avoid using it in validation.
             this.inputElement.step = 'any';
-            this.__stepChangedCalled = true;
           } else {
             this.inputElement.step = step;
           }
+          this.__stepChangedCalled = true;
         }
 
         _minChanged(min) {

--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -303,8 +303,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _stepChanged(step) {
           // Avoid using initial value in validation
-          this.__validateByStep = this.__stepChangedCalled
-            || (!this.__stepChangedCalled && this.getAttribute('step') !== null);
+          this.__validateByStep = this.__stepChangedCalled || this.getAttribute('step') !== null;
           this.inputElement.step = this.__validateByStep ? step : 'any';
 
           this.__stepChangedCalled = true;

--- a/test/integer-field.html
+++ b/test/integer-field.html
@@ -215,7 +215,7 @@
 
         it('should allow setting positive integer as string', () => {
           integerField.step = '5';
-          expect(integerField.step).to.eql('5');
+          expect(integerField.step).to.eql(5);
         });
 
         ['foo', '-1', -1, '1.2', 1.2, '+1', '1e1', undefined, null, {}].forEach(invalidStep => {

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -17,6 +17,11 @@
       <vaadin-number-field></vaadin-number-field>
     </template>
   </test-fixture>
+  <test-fixture id="step">
+    <template>
+      <vaadin-number-field step="1.5"></vaadin-number-field>
+    </template>
+  </test-fixture>
 
   <script>
     describe('number-field', () => {
@@ -772,6 +777,14 @@
             numberField.value = invalidValue;
             expect(numberField.validate()).to.be.false;
           });
+        });
+
+        it('should validate by step when defined as attribute', () => {
+          const numberField = fixture('step');
+          numberField.value = 1;
+          expect(numberField.validate()).to.be.false;
+          numberField.value = 1.5;
+          expect(numberField.validate()).to.be.true;
         });
 
         it('should use min as step basis in validation when both are defined', () => {

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -17,9 +17,14 @@
       <vaadin-number-field></vaadin-number-field>
     </template>
   </test-fixture>
-  <test-fixture id="step">
+  <test-fixture id="step-as-attribute">
     <template>
       <vaadin-number-field step="1.5"></vaadin-number-field>
+    </template>
+  </test-fixture>
+  <test-fixture id="default-step-as-attribute">
+    <template>
+      <vaadin-number-field step="1"></vaadin-number-field>
     </template>
   </test-fixture>
 
@@ -780,10 +785,18 @@
         });
 
         it('should validate by step when defined as attribute', () => {
-          const numberField = fixture('step');
+          const numberField = fixture('step-as-attribute');
           numberField.value = 1;
           expect(numberField.validate()).to.be.false;
           numberField.value = 1.5;
+          expect(numberField.validate()).to.be.true;
+        });
+
+        it('should validate by step when default value defined as attribute', () => {
+          const numberField = fixture('default-step-as-attribute');
+          numberField.value = 1.5;
+          expect(numberField.validate()).to.be.false;
+          numberField.value = 1;
           expect(numberField.validate()).to.be.true;
         });
 

--- a/test/number-field.html
+++ b/test/number-field.html
@@ -760,6 +760,42 @@
           expect(numberField.validate(), 'value should not be greater than max').to.be.false;
         });
 
+        it('should validate by step when defined by user', () => {
+          numberField.step = 1.5;
+
+          [-6, -1.5, 0, 1.5, 4.5].forEach(validValue => {
+            numberField.value = validValue;
+            expect(numberField.validate()).to.be.true;
+          });
+
+          [-3.5, -1, 2, 2.5].forEach(invalidValue => {
+            numberField.value = invalidValue;
+            expect(numberField.validate()).to.be.false;
+          });
+        });
+
+        it('should use min as step basis in validation when both are defined', () => {
+          numberField.min = 1;
+          numberField.step = 1.5;
+
+          [1, 2.5, 4, 5.5].forEach(validValue => {
+            numberField.value = validValue;
+            expect(numberField.validate()).to.be.true;
+          });
+
+          [1.5, 3, 5].forEach(invalidValue => {
+            numberField.value = invalidValue;
+            expect(numberField.validate()).to.be.false;
+          });
+        });
+
+        it('should not validate by step when only min and max are set', () => {
+          numberField.min = 1;
+          numberField.max = 5;
+          numberField.value = 1.5; // would be invalid by default step=1
+          expect(numberField.validate()).to.be.true;
+        });
+
         describe('removing validation constraints', () => {
           it('should update "invalid" state when "min" is removed', () => {
             numberField.value = '42';


### PR DESCRIPTION
setting the min or max property should not trigger step-based validation

fix #420