### PR TITLE
feat/refactor: add _enabledCharPattern property

### DIFF
--- a/src/vaadin-integer-field.html
+++ b/src/vaadin-integer-field.html
@@ -36,8 +36,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         ready() {
           super.ready();
-          this.inputElement.addEventListener('drop', this.__onDrop.bind(this));
-          this.inputElement.addEventListener('paste', this.__onPaste.bind(this));
+          this._enabledCharPattern = '[-+\\d]';
         }
 
         _valueChanged(newVal, oldVal) {
@@ -48,34 +47,6 @@ This program is available under Apache License Version 2.0, available at https:/
             return;
           }
           super._valueChanged(newVal, oldVal);
-        }
-
-        _onKeyDown(e) {
-          if (!this.__shouldAcceptKey(e)) {
-            e.preventDefault();
-          }
-          super._onKeyDown(e);
-        }
-
-        __shouldAcceptKey(event) {
-          return (event.metaKey || event.ctrlKey)
-            || !event.key // allow typing anything if event.key is not supported
-            || event.key.length !== 1 // allow "Backspace", "ArrowLeft" etc.
-            || /^[-+\d]$/.test(event.key);
-        }
-
-        __onDrop(e) {
-          const draggedText = e.dataTransfer.getData('text');
-          if (!this.__isValidInput(draggedText)) {
-            e.preventDefault();
-          }
-        }
-
-        __onPaste(e) {
-          const pastedText = (e.clipboardData || window.clipboardData).getData('text');
-          if (!this.__isValidInput(pastedText)) {
-            e.preventDefault();
-          }
         }
 
         _stepChanged(newVal, oldVal) {
@@ -91,10 +62,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
         __isInteger(value) {
           return /^(-\d)?\d*$/.test(String(value));
-        }
-
-        __isValidInput(value) {
-          return /^[\d+-]*$/.test(String(value));
         }
 
         __hasOnlyDigits(value) {

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -303,6 +303,18 @@ This program is available under Apache License Version 2.0, available at https:/
           type: Boolean
         },
 
+        /**
+         * A pattern matched against individual characters the user inputs.
+         * When set, the field will prevent:
+         * - `keyDown` events if the entered key doesn't match `/^_enabledCharPattern$/`
+         * - `paste` events if the pasted text doesn't match `/^_enabledCharPattern*$/`
+         * - `drop` events if the dropped text doesn't match `/^_enabledCharPattern*$/`
+         *
+         * For example, to enable entering only numbers and minus signs,
+         * `_enabledCharPattern = "[\\d-]"`
+         */
+        _enabledCharPattern: String,
+
         _labelId: String,
 
         _errorId: String,
@@ -317,7 +329,8 @@ This program is available under Apache License Version 2.0, available at https:/
         '_hostAccessiblePropsChanged(' + HOST_PROPS.accessible.join(', ') + ')',
         '_getActiveErrorId(invalid, errorMessage, _errorId)',
         '_getActiveLabelId(label, _labelId, _inputId)',
-        '__observeOffsetHeight(errorMessage, invalid, label)'
+        '__observeOffsetHeight(errorMessage, invalid, label)',
+        '__enabledCharPatternChanged(_enabledCharPattern)'
       ];
     }
 
@@ -539,6 +552,8 @@ This program is available under Apache License Version 2.0, available at https:/
       node.addEventListener('change', this._boundOnChange);
       node.addEventListener('blur', this._boundOnBlur);
       node.addEventListener('focus', this._boundOnFocus);
+      node.addEventListener('paste', this._boundOnPaste);
+      node.addEventListener('drop', this._boundOnDrop);
     }
 
     _removeInputListeners(node) {
@@ -546,6 +561,8 @@ This program is available under Apache License Version 2.0, available at https:/
       node.removeEventListener('change', this._boundOnChange);
       node.removeEventListener('blur', this._boundOnBlur);
       node.removeEventListener('focus', this._boundOnFocus);
+      node.removeEventListener('paste', this._boundOnPaste);
+      node.removeEventListener('drop', this._boundOnDrop);
     }
 
     ready() {
@@ -557,6 +574,8 @@ This program is available under Apache License Version 2.0, available at https:/
       this._boundOnChange = this._onChange.bind(this);
       this._boundOnBlur = this._onBlur.bind(this);
       this._boundOnFocus = this._onFocus.bind(this);
+      this._boundOnPaste = this._onPaste.bind(this);
+      this._boundOnDrop = this._onDrop.bind(this);
 
       const defaultInput = this.shadowRoot.querySelector('[part="value"]');
       this._slottedInput = this.querySelector(`${this._slottedTagName}[slot="${this._slottedTagName}"]`);
@@ -650,6 +669,40 @@ This program is available under Apache License Version 2.0, available at https:/
         this.clear();
         dispatchChange && this.inputElement.dispatchEvent(new Event('change', {bubbles: !this._slottedInput}));
       }
+
+      if (this._enabledCharPattern && !this.__shouldAcceptKey(e)) {
+        e.preventDefault();
+      }
+    }
+
+    __shouldAcceptKey(event) {
+      return (event.metaKey || event.ctrlKey)
+        || !event.key // allow typing anything if event.key is not supported
+        || event.key.length !== 1 // allow "Backspace", "ArrowLeft" etc.
+        || this.__enabledCharRegExp.test(event.key);
+    }
+
+    _onPaste(e) {
+      if (this._enabledCharPattern) {
+        const pastedText = (e.clipboardData || window.clipboardData).getData('text');
+        if (!this.__enabledTextRegExp.test(pastedText)) {
+          e.preventDefault();
+        }
+      }
+    }
+
+    _onDrop(e) {
+      if (this._enabledCharPattern) {
+        const draggedText = e.dataTransfer.getData('text');
+        if (!this.__enabledTextRegExp.test(draggedText)) {
+          e.preventDefault();
+        }
+      }
+    }
+
+    __enabledCharPatternChanged(_enabledCharPattern) {
+      this.__enabledCharRegExp = _enabledCharPattern && new RegExp('^' + _enabledCharPattern + '$');
+      this.__enabledTextRegExp = _enabledCharPattern && new RegExp('^' + _enabledCharPattern + '*$');
     }
 
     _addIEListeners(node) {


### PR DESCRIPTION
Protected feature extracted from `<vaadin-integer-field>` to allow
reusing the same logic for `BigDecimalField`.