### PR TITLE
fix(lumo): use correct focus state selector

### DIFF
--- a/theme/lumo/vaadin-text-field-styles.html
+++ b/theme/lumo/vaadin-text-field-styles.html
@@ -45,8 +45,8 @@
       }
 
       [part="value"]:focus,
-      [part="input-field"] ::slotted(input):focus,
-      [part="input-field"] ::slotted(textarea):focus {
+      :host([focused]) [part="input-field"] ::slotted(input),
+      :host([focused]) [part="input-field"] ::slotted(textarea) {
         -webkit-mask-image: none;
         mask-image: none;
       }


### PR DESCRIPTION
Fixes #335 

It turns out that the following CSS does not work and breaks the whole block:

```css
::slotted(input):focus
```

So I had to use `:host([focused])` instead to fix that.