### PR TITLE
fix: ARIA for disabled, required, readonly and invalid states

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: "66.0"
+  firefox: latest
   chrome: stable
 
 jobs:
@@ -22,12 +22,12 @@ jobs:
     - if: type = pull_request
       env: POLYMER=2
       addons:
-        firefox: "66.0"
+        firefox: latest
         chrome: stable
     - if: type = pull_request
       env: POLYMER=3
       addons:
-        firefox: "66.0"
+        firefox: latest
         chrome: stable
     - if: type = cron
       env: TEST_SUITE=unit_tests POLYMER=2

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -117,8 +117,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
   const HOST_PROPS = {
     default: ['list', 'autofocus', 'pattern', 'autocapitalize', 'autocorrect', 'maxlength',
-      'minlength', 'name', 'placeholder', 'autocomplete', 'title'],
-    accessible: ['disabled', 'readonly', 'required', 'invalid']
+      'minlength', 'name', 'placeholder', 'autocomplete', 'title', 'disabled', 'readonly', 'required'],
+    accessible: ['invalid']
   };
 
   const PROP_TYPE = {
@@ -499,10 +499,10 @@ This program is available under Apache License Version 2.0, available at https:/
       const input = this.inputElement;
       const attributeNames = HOST_PROPS[type];
 
-      if (type === 'accessible') {
+      if (type === PROP_TYPE.ACCESSIBLE) {
         attributeNames.forEach((attr, index) => {
           this._setOrToggleAttribute(attr, attributesValues[index], input);
-          this._setOrToggleAttribute(`aria-${attr}`, attributesValues[index], input);
+          this._setOrToggleAttribute(`aria-${attr}`, attributesValues[index] ? 'true' : false, input);
         });
       } else {
         attributeNames.forEach((attr, index) => {

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -118,7 +118,7 @@
   <test-fixture id="vaadin-text-area-multiple-fields">
     <template>
       <vaadin-text-area></vaadin-text-area>
-      <vaadin-text-area></vaadin-text-field>
+      <vaadin-text-area></vaadin-text-area>
     </template>
   </test-fixture>
 
@@ -129,7 +129,7 @@
       </vaadin-text-area>
       <vaadin-text-area>
         <textarea slot="textarea"></textarea>
-      </vaadin-text-field>
+      </vaadin-text-area>
     </template>
   </test-fixture>
   

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -221,21 +221,30 @@
             });
 
             it('should not be marked required', function() {
-              expect(input.hasAttribute('aria-required')).to.be.false;
+              expect(input.hasAttribute('required')).to.be.false;
             });
 
             it('should be marked required', function() {
               tf.required = true;
-              expect(input.hasAttribute('aria-required')).to.be.true;
+              expect(input.getAttribute('required')).to.equal('');
             });
 
             it('should not be marked readonly', function() {
-              expect(input.hasAttribute('aria-readonly')).to.be.false;
+              expect(input.hasAttribute('readonly')).to.be.false;
             });
 
             it('should be marked readonly', function() {
               tf.readonly = true;
-              expect(input.hasAttribute('aria-readonly')).to.be.true;
+              expect(input.getAttribute('readonly')).to.equal('');
+            });
+
+            it('should not be marked disabled', function() {
+              expect(input.hasAttribute('disabled')).to.be.false;
+            });
+
+            it('should be marked disabled', function() {
+              tf.disabled = true;
+              expect(input.getAttribute('disabled')).to.equal('');
             });
 
             describe('clear icon button', function() {
@@ -316,7 +325,7 @@
             });
 
             it('should be marked invalid', function() {
-              expect(input.hasAttribute('aria-invalid')).to.be.true;
+              expect(input.getAttribute('aria-invalid')).to.equal('true');
             });
 
             it('should not be marked invalid', function() {


### PR DESCRIPTION
Do not set `aria-disabled`, `aria-required` or `aria-readonly` attributes since they are unnecessary when we're using the native HTML `disabled`, `required` and `readonly` attributes. Previously these three `aria-*` attributes were set with incorrect value (valid values for these are string `"true"` or `"false"`).

Use correct values for setting `aria-invalid` attribute (using string `"true"` when invalid).

Fixes #430.