### PR TITLE
Don't use :not() selector for overflow-mask-image

### DIFF
--- a/theme/lumo/vaadin-number-field-styles.html
+++ b/theme/lumo/vaadin-number-field-styles.html
@@ -34,6 +34,13 @@
       [part="increase-button"]::before {
         margin-top: 0.2em;
       }
+
+      /* RTL specific styles */
+
+      :host([dir="rtl"]) [part="value"],
+      :host([dir="rtl"]) [part="input-field"] ::slotted(input) {
+        --_lumo-text-field-overflow-mask-image: linear-gradient(to left, transparent, #000 1.25em);
+      }
     </style>
   </template>
 </dom-module>

--- a/theme/lumo/vaadin-text-field-styles.html
+++ b/theme/lumo/vaadin-text-field-styles.html
@@ -297,9 +297,9 @@
         transform-origin: 0% 0;
       }
 
-      :host([dir="rtl"]:not(vaadin-number-field):not(vaadin-big-decimal-field)) [part="value"],
-      :host([dir="rtl"]:not(vaadin-number-field):not(vaadin-big-decimal-field)) [part="input-field"] ::slotted(input),
-      :host([dir="rtl"]:not(vaadin-number-field):not(vaadin-big-decimal-field)) [part="input-field"] ::slotted(textarea) {
+      :host([dir="rtl"]) [part="value"],
+      :host([dir="rtl"]) [part="input-field"] ::slotted(input),
+      :host([dir="rtl"]) [part="input-field"] ::slotted(textarea) {
         --_lumo-text-field-overflow-mask-image: linear-gradient(to right, transparent, #000 1.25em);
       }
 


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-text-field-flow/issues/302