### PR TITLE
Fix user input

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -424,11 +424,12 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
-      // Value can remain the same on input when pasting
-      if (!e.__fromClearButton && this.value !== e.target.value) {
+      if (!e.__fromClearButton) {
         this.__userInput = true;
       }
+
       this.value = e.target.value;
+      this.__userInput = false;
     }
 
     // NOTE(yuriy): Workaround needed for IE11 and Edge for proper displaying
@@ -485,7 +486,6 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       if (this.__userInput) {
-        this.__userInput = false;
         return;
       } else if (newVal !== undefined) {
         this.inputElement.value = newVal;

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -424,7 +424,8 @@ This program is available under Apache License Version 2.0, available at https:/
         }
       }
 
-      if (!e.__fromClearButton) {
+      // Value can remain the same on input when pasting
+      if (!e.__fromClearButton && this.value !== e.target.value) {
         this.__userInput = true;
       }
       this.value = e.target.value;

--- a/test/text-field.html
+++ b/test/text-field.html
@@ -567,6 +567,26 @@
 
       });
 
+      describe('value property', function() {
+        let textField, input;
+
+        beforeEach(function() {
+          textField = fixture(`default${fixtureName}`);
+          input = textField.inputElement;
+        });
+
+        it('should not consider updating the value as user input if the value is not changed', () => {
+          const event = new Event('input', {
+            bubbles: true,
+            cancelable: true
+          });
+          input.dispatchEvent(event);
+
+          textField.value = 'foo';
+          expect(input.value).to.equal('foo');
+        });
+      });
+
       describe(`events ${condition}`, function() {
         let textField, input;
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-text-field-flow/issues/273

**Description:**
`paste` is also triggering `input` event.
In case this event is triggered when value wasn't changed (i.e. value was replaced with `paste`, or `maxlength` is set and `paste` is done), `__userInput` will be set to `true` [here](https://github.com/vaadin/vaadin-text-field/blob/bd388d6bab1a08ae9fb5f68e95d513004c9592cb/src/vaadin-text-field-mixin.html#L428), but [updating the value](https://github.com/vaadin/vaadin-text-field/blob/bd388d6bab1a08ae9fb5f68e95d513004c9592cb/src/vaadin-text-field-mixin.html#L430) won't pass polymer dirty check, so the `__userInput` will be preserved for the next programmatic value update and input `value` won't be [updated](https://github.com/vaadin/vaadin-text-field/blob/bd388d6bab1a08ae9fb5f68e95d513004c9592cb/src/vaadin-text-field-mixin.html#L487).

**Important note:**
It's possible to check for specifically `paste` action (i.e. with `e.inputType` or within `onPaste`), but it doesn't make sense to preserve `__userInput` in any case if dirty check won't be passed for `valueChange` afterwards, so general short solution is implemented in the PR.
(It's easier to test and covers the `paste` cases, cannot come up with other cases when value won't be changed and `input` event is triggered)