### PR TITLE
fix: workaround Polymer getProperty with mixins/observers

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -923,6 +923,11 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    // Workaround for https://github.com/Polymer/polymer/issues/5259
+    _getProperty(property) {
+      return this.__data ? this.__data[property] : undefined;
+    }
+
     /**
      * Fired when the user commits a value change.
      *

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -924,8 +924,12 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     // Workaround for https://github.com/Polymer/polymer/issues/5259
-    _getProperty(property) {
-      return this.__data ? this.__data[property] : undefined;
+    get __data() {
+      return this.__dataValue || {};
+    }
+
+    set __data(value) {
+      this.__dataValue = value;
     }
 
     /**

--- a/test/integer-field.html
+++ b/test/integer-field.html
@@ -19,6 +19,14 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="mixed">
+    <template>
+      <vaadin-integer-field label="integer fld"></vaadin-integer-field>
+      <vaadin-text-field label="text fld"></vaadin-text-field>
+      <vaadin-number-field label="number fld"></vaadin-number-field>
+    </template>
+  </test-fixture>
+
   <script>
     describe('integer-field', () => {
 
@@ -226,6 +234,14 @@
           });
 
         });
+      });
+
+    });
+
+    describe('mixed', () => {
+
+      it('should work together with text-field and number-field', () => {
+        expect(() => fixture('mixed')).to.not.throw(Error);
       });
 
     });


### PR DESCRIPTION
See https://github.com/Polymer/polymer/issues/5259

Fixes https://github.com/vaadin/vaadin-text-field-flow/issues/317