### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-number-field.html
+++ b/src/vaadin-number-field.html
@@ -119,6 +119,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * Set to true to display value increase/decrease controls.
+             * @attr {boolean} has-controls
              * @type {boolean}
              */
             hasControls: {

--- a/src/vaadin-password-field.html
+++ b/src/vaadin-password-field.html
@@ -87,6 +87,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return {
             /**
              * Set to true to hide the eye icon which toggles the password visibility.
+             * @attr {boolean} reveal-button-hidden
              * @type {boolean}
              */
             revealButtonHidden: {
@@ -96,6 +97,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * True if the password is visible ([type=text]).
+             * @attr {boolean} password-visible
              * @type {boolean}
              */
             passwordVisible: {

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -178,6 +178,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Set to true to display the clear icon which clears the input.
+         * @attr {boolean} clear-button-visible
          * @type {boolean}
          */
         clearButtonVisible: {
@@ -187,6 +188,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Error to show when the input value is invalid.
+         * @attr {string} error-message
          * @type {string}
          */
         errorMessage: {
@@ -295,6 +297,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Specifies that the text field has value.
+         * @attr {boolean} has-value
          */
         hasValue: {
           type: Boolean,
@@ -304,6 +307,7 @@ This program is available under Apache License Version 2.0, available at https:/
         /**
          * When set to true, user is prevented from typing a value that
          * conflicts with the given `pattern`.
+         * @attr {boolean} prevent-invalid-input
          */
         preventInvalidInput: {
           type: Boolean


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-core/issues/257

Note, this is a PR for 2.7 branch. When cherry-picking it to master, we would need to add attribute for `helperText`.