### PR TITLE
ci: ignore tags, support skipping [skip ci]

### DIFF
--- a/.github/workflows/sauce.yml
+++ b/.github/workflows/sauce.yml
@@ -1,10 +1,14 @@
 name: sauce
 
-on: [push]
+on:
+  push:
+    tags-ignore:
+      - 'v**'
 
 jobs:
   polymer-2:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2
@@ -29,6 +33,7 @@ jobs:
 
   polymer-3:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2
@@ -60,6 +65,7 @@ jobs:
 
   visual-tests:
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently when doing `magi release` there are two builds: one for commit and another one for git tag.

This causes duplicate builds exceeding SauceLabs limit of 5 tunnels and results in a failure:

![Screenshot 2020-11-25 at 16 04 46](https://user-images.githubusercontent.com/10589913/100237783-0f854b80-2f38-11eb-9d33-d9daca5b748c.png)

Looks like `tags-ignore` [config option](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags) should help.

Also, this PR adds `[skip ci]` support.