### PR TITLE
chore: align JSDoc, add missing events [skip ci]

### DIFF
--- a/src/vaadin-email-field.d.ts
+++ b/src/vaadin-email-field.d.ts
@@ -14,6 +14,8 @@ import { TextFieldElement } from './vaadin-text-field.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-email-field.js
+++ b/src/vaadin-email-field.js
@@ -40,6 +40,8 @@ registerStyles(
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *

--- a/src/vaadin-integer-field.d.ts
+++ b/src/vaadin-integer-field.d.ts
@@ -8,6 +8,8 @@ import { NumberFieldElement } from './vaadin-number-field.js';
  * </vaadin-integer-field>
  * ```
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-integer-field.js
+++ b/src/vaadin-integer-field.js
@@ -13,6 +13,8 @@ import { NumberFieldElement } from './vaadin-number-field.js';
  * </vaadin-integer-field>
  * ```
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *

--- a/src/vaadin-number-field.d.ts
+++ b/src/vaadin-number-field.d.ts
@@ -8,6 +8,8 @@ import { TextFieldElement } from './vaadin-text-field.js';
  * </vaadin-number-field>
  * ```
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-number-field.js
+++ b/src/vaadin-number-field.js
@@ -92,6 +92,8 @@ let memoizedTemplate;
  * </vaadin-number-field>
  * ```
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *

--- a/src/vaadin-password-field.d.ts
+++ b/src/vaadin-password-field.d.ts
@@ -26,6 +26,8 @@ import { TextFieldElement } from './vaadin-text-field.js';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-password-field.js
+++ b/src/vaadin-password-field.js
@@ -63,6 +63,8 @@ let memoizedTemplate;
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *

--- a/src/vaadin-text-area.d.ts
+++ b/src/vaadin-text-area.d.ts
@@ -57,6 +57,8 @@ import { TextFieldEventMap } from './interfaces';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-text-area.js
+++ b/src/vaadin-text-area.js
@@ -58,6 +58,8 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *

--- a/src/vaadin-text-field.d.ts
+++ b/src/vaadin-text-field.d.ts
@@ -64,6 +64,8 @@ import { TextFieldEventMap } from './interfaces';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */

--- a/src/vaadin-text-field.js
+++ b/src/vaadin-text-field.js
@@ -65,6 +65,8 @@ import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
+ * @fires {Event} input - Fired when the value is changed by the user: on every typing keystroke, and the value is cleared using the clear button.
+ * @fires {Event} change - Fired when the user commits a value change.
  * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *


### PR DESCRIPTION
Added missing `change` and `input` events to align with the [API docs](https://cdn.vaadin.com/vaadin-text-field/3.0.0-alpha1/#/elements/vaadin-text-field#events).

There is also `iron-resize` event but it's mostly internal and was implemented mainly for `vaadin-grid` editor (#372)
So I don't think we should encourage using it, assuming that we will move away from Polymer in future.