### PR TITLE
fix: remove an outdated workaround for Safari

### DIFF
--- a/src/vaadin-text-area.js
+++ b/src/vaadin-text-area.js
@@ -193,8 +193,6 @@ class TextAreaElement extends ElementMixin(TextFieldMixin(ControlStateMixin(Them
       // Fix the input element width so its scroll height isn't affected by host's disappearing scrollbars
       input.style.maxWidth = inputWidth;
       input.style.height = 'auto';
-      // Avoid a jumpy Safari rendering issue
-      inputField.style.display = 'block';
     }
     this._oldValueLength = valueLength;
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-flow-components/issues/452

Seems that the original issue happens because of [this workaround](https://github.com/vaadin/vaadin-text-field/blob/154933d877f6bff2520397b79cc26788629c8101/src/vaadin-text-area.js#L197). According to the comment above the line, the workaround could be scoped to target Safari only, but since I couldn't reproduce the "jumpy Safari rendering" mentioned in the comment anymore (the workaround is from 2017), decided to just remove it.

This PR doesn't have an associated test case, because it would require using native focus.