### PR TITLE
fix: scope a Safari-specific workaround

### DIFF
--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -200,8 +200,6 @@ This program is available under Apache License Version 2.0, available at https:/
             // Fix the input element width so its scroll height isn't affected by host's disappearing scrollbars
             input.style.maxWidth = inputWidth;
             input.style.height = 'auto';
-            // Avoid a jumpy Safari rendering issue
-            inputField.style.display = 'block';
           }
           this._oldValueLength = valueLength;
 

--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -164,6 +164,7 @@ This program is available under Apache License Version 2.0, available at https:/
           super.ready();
           this._updateHeight();
           this.addEventListener('animationend', this._onAnimationEnd);
+          this.__safari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
         }
 
         /** @private */
@@ -200,6 +201,10 @@ This program is available under Apache License Version 2.0, available at https:/
             // Fix the input element width so its scroll height isn't affected by host's disappearing scrollbars
             input.style.maxWidth = inputWidth;
             input.style.height = 'auto';
+            // Avoid a jumpy Safari rendering issue
+            if (this.__safari) {
+              inputField.style.display = 'block';
+            }
           }
           this._oldValueLength = valueLength;
 


### PR DESCRIPTION
Cherry-pick https://github.com/vaadin/vaadin-text-field/pull/568