### PR TITLE
fix: workaround disabled textarea freezing Firefox (#2981)

### DIFF
--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -49,6 +49,11 @@ This program is available under Apache License Version 2.0, available at https:/
       :host {
         animation: 1ms vaadin-text-area-appear;
       }
+
+      /* Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1739079 */
+      :host([disabled]) [part='value'] {
+        user-select: none;
+      }
     </style>
 
     <div class="vaadin-text-area-container">


### PR DESCRIPTION
Backport https://github.com/vaadin/web-components/pull/2981 for V14