### PR TITLE
refactor: make keydown event listener an arrow function to allow overwrites

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -696,7 +696,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this.$.clearButton.addEventListener('mousedown', () => this._valueClearing = true);
       this.$.clearButton.addEventListener('mouseleave', () => this._valueClearing = false);
       this.$.clearButton.addEventListener('click', this._onClearButtonClick.bind(this));
-      this.addEventListener('keydown', this._onKeyDown.bind(this));
+      this.addEventListener('keydown', e => this._onKeyDown(e));
 
       var uniqueId = Vaadin.TextFieldMixin._uniqueId = 1 + Vaadin.TextFieldMixin._uniqueId || 0;
       this._errorId = `${this.constructor.is}-error-${uniqueId}`;


### PR DESCRIPTION
## Description

The `vaadin-combo-box` component uses `vaadin-text-field` internally and needs to do some actions when the <kbd>Esc</kbd> key is pressed. These actions include changing the value of the text field, but there's an event listener in `vaadin-text-field-mixin` that also acts on its value.

To let `vaadin-combo-box` overrite this event listener, we must change the callback to an arrow function that calls the function we use and then override the function being called inside the arrow function in the particular instance in the combo-box.

Related https://github.com/vaadin/web-components/issues/984

## Type of change

- Refactor