### PR TITLE
fix: don't cancel text-area wheel event unnecessarily (CP)

### DIFF
--- a/src/vaadin-text-area.html
+++ b/src/vaadin-text-area.html
@@ -187,9 +187,13 @@ This program is available under Apache License Version 2.0, available at https:/
           // event, scrolling manually and then synchronously updating the scroll position CSS variable
           // allows us to avoid some jumpy behavior that would occur on wheel otherwise.
           this._inputField.addEventListener('wheel', (e) => {
-            e.preventDefault();
+            const scrollTopBefore = this._inputField.scrollTop;
             this._inputField.scrollTop += e.deltaY;
-            this.__scrollPositionUpdated();
+
+            if (scrollTopBefore !== this._inputField.scrollTop) {
+              e.preventDefault();
+              this.__scrollPositionUpdated();
+            }
           });
 
           this.__scrollPositionUpdated();

--- a/test/text-area.html
+++ b/test/text-area.html
@@ -470,7 +470,7 @@
       });
 
       it('should not cancel wheel event if text area is not scrolled', () => {
-        const e = wheel({ deltaY: -10 });
+        const e = wheel({deltaY: -10});
         expect(e.defaultPrevented).to.be.false;
       });
 

--- a/test/text-area.html
+++ b/test/text-area.html
@@ -469,6 +469,11 @@
         expect(e.defaultPrevented).to.be.true;
       });
 
+      it('should not cancel wheel event if text area is not scrolled', () => {
+        const e = wheel({ deltaY: -10 });
+        expect(e.defaultPrevented).to.be.false;
+      });
+
       it('should update value on resize', async() => {
         inputField.scrollTop = 10;
         await oneEvent(inputField, 'scroll');


### PR DESCRIPTION
Backport https://github.com/vaadin/web-components/pull/3495 to V14