### PR TITLE
fix: prevent initial validation when the field is initialized as invalid (CP: 14)

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -480,7 +480,7 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     _valueChanged(newVal, oldVal) {
       // setting initial value to empty string, skip validation
-      if (newVal === '' && oldVal === undefined) {
+      if (oldVal === undefined) {
         return;
       }
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -7,6 +7,7 @@
     "WCT": false,
     "describe": false,
     "beforeEach": false,
+    "afterEach": false,
     "fixture": false,
     "it": false,
     "expect": false,
@@ -15,6 +16,7 @@
     "MockInteractions": false,
     "animationFrameFlush": false,
     "listenOnce": false,
-    "oneEvent": false
+    "oneEvent": false,
+    "nextRender": false
   }
 }

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -10,4 +10,10 @@
   window.oneEvent = (element, eventName) => {
     return new Promise((resolve) => listenOnce(element, eventName, resolve));
   };
+
+  window.nextRender = (element) => {
+    return new Promise(resolve => {
+      Polymer.RenderStatus.afterNextRender(element, resolve);
+    });
+  };
 </script>

--- a/test/validation.html
+++ b/test/validation.html
@@ -13,7 +13,7 @@
   <link rel="import" href="../vaadin-text-area.html">
   <link rel="import" href="../vaadin-text-field.html">
   <link rel="import" href="../../iron-form/iron-form.html">
-
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -334,7 +334,40 @@
             expect(field.invalid).to.be.true;
           });
         });
+      });
+    });
 
+    describe('initial validation', () => {
+      let field, validateSpy;
+
+      beforeEach(() => {
+        field = document.createElement('vaadin-email-field');
+        validateSpy = sinon.spy(field, 'validate');
+      });
+
+      afterEach(() => {
+        field.remove();
+      });
+
+      it('should not validate by default', async() => {
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value', async() => {
+        field.value = 'foo@example.com';
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value and invalid', async() => {
+        field.value = 'foo@example.com';
+        field.invalid = true;
+        document.body.appendChild(field);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
       });
     });
   </script>


### PR DESCRIPTION
Backports web-components#4138 as part of an EoD task

> ## Description
> The PR prevents the initial validation that could previously take place when the field is initially provided with a non-empty value and is initially marked `invalid`:
> 
> ```js
> const textField = document.createElement('vaadin-text-field');
> textField.value = 'Initial Value';
> textField.invalid = true;
> document.appendChild(textField);
> ```
> 
> The initial validation is problematic because it fires a `validated` event that may result in an `invalid` state reset on the Flow side, see [vaadin/flow-components#3429 (comment)](https://github.com/vaadin/flow-components/pull/3429#issuecomment-1177365424) for a more detailed case.
> 
> Part of #4150
> 
> ## Covered components
> This PR only fixes the issue for the components that extend `InputFieldMixin`:
> 
> * [x]  text-field
> * [x]  email-field
> * [x]  password-field
> * [x]  text-area
> * [x]  number-field
> * [x]  integer-field
> 
> Other components will be covered in the next PRs.
> 
> ## Type of change
> * [x]  Bugfix
> 
> ## Checklist
> * [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
> * [x]  I have added a description following the guideline.
> * [x]  The issue is created in the corresponding repository and I have referenced it.
> * [x]  I have added tests to ensure my change is effective and works as intended.
> * [x]  New and existing tests are passing locally with my change.
> * [x]  I have performed self-review and corrected misspellings.

