### PR TITLE
feat: fire a validated event on validation and add shouldSetInvalid method

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -719,7 +719,10 @@ This program is available under Apache License Version 2.0, available at https:/
      * @return {boolean} True if the value is valid.
      */
     validate() {
-      return !(this.invalid = !this.checkValidity());
+      const isValid = this.checkValidity();
+      this.invalid = !isValid;
+      this.dispatchEvent(new CustomEvent('validated', {detail: {valid: isValid}}));
+      return isValid;
     }
 
     clear() {

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -618,7 +618,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       if (!required && !minlength && !maxlength && !pattern) {
-        this.invalid = false;
+        this._setInvalid(false);
       } else {
         this.validate();
       }
@@ -713,6 +713,27 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /**
+     * @param {boolean} invalid
+     * @protected
+     */
+    _setInvalid(invalid) {
+      if (this._shouldSetInvalid(invalid)) {
+        this.invalid = invalid;
+      }
+    }
+
+    /**
+     * Override this method to define whether the given `invalid` state should be set.
+     *
+     * @param {boolean} _invalid
+     * @return {boolean}
+     * @protected
+     */
+    _shouldSetInvalid(_invalid) {
+      return true;
+    }
+  
+    /**
      * Returns true if `value` is valid.
      * `<iron-form>` uses this to check the validity for all its elements.
      *
@@ -720,7 +741,7 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     validate() {
       const isValid = this.checkValidity();
-      this.invalid = !isValid;
+      this._setInvalid(!isValid);
       this.dispatchEvent(new CustomEvent('validated', {detail: {valid: isValid}}));
       return isValid;
     }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -2,6 +2,10 @@
   "parserOptions": {
     "ecmaVersion": 8
   },
+  "rules": {
+    "no-undef": 0,
+    "no-unused-vars": 0
+  },
   "globals": {
     "HTMLImports": false,
     "WCT": false,

--- a/test/email-field.html
+++ b/test/email-field.html
@@ -70,6 +70,30 @@
       });
 
       describe('validation', () => {
+        describe('events', () => {
+          it('should fire a validated event on validation success', () => {
+            const validatedSpy = sinon.spy();
+            emailField.addEventListener('validated', validatedSpy);
+            emailField.validate();
+
+            expect(validatedSpy.calledOnce).to.be.true;
+            const event = validatedSpy.firstCall.args[0];
+            expect(event.detail.valid).to.be.true;
+          });
+
+          it('should fire a validated event on validation failure', () => {
+            const validatedSpy = sinon.spy();
+            emailField.addEventListener('validated', validatedSpy);
+            emailField.required = true;
+            emailField.validate();
+
+            expect(validatedSpy.calledOnce).to.be.true;
+            const event = validatedSpy.firstCall.args[0];
+            expect(event.detail.valid).to.be.false;
+          });
+
+        });
+
         describe('valid email addresses', () => {
           validAddresses.map(address => {
             it(address, () => {

--- a/test/invalid-common.js
+++ b/test/invalid-common.js
@@ -1,0 +1,48 @@
+const cachedWrappers = [];
+const templates = {};
+/**
+ * Creates a wrapper as a direct child of `<body>` to put the tested element into.
+ * Need to be in the DOM to test for example `connectedCallback()` on elements.
+ *
+ * @param {!Element} parentNode
+ * @return {Element} wrapping node
+ */
+function fixtureWrapper(parentNode = document.createElement('div')) {
+  document.body.appendChild(parentNode);
+  cachedWrappers.push(parentNode);
+  return parentNode;
+}
+
+// # sourceMappingURL=fixture-wrapper.js.map
+
+/**
+ * Creates a `<template>` element from a provided string template.
+ *
+ * @param {string} html
+ * @return {HTMLTemplateElement}
+ */
+function template(html) {
+  let tpl = templates[html];
+  if (!tpl) {
+    tpl = document.createElement('template');
+    tpl.innerHTML = html;
+    templates[html] = tpl;
+  }
+  return tpl;
+}
+/**
+ * Setups an element synchronously from the provided string template and puts it in the DOM.
+ * Uses `document.importNode` to ensure proper custom elements upgrade timings.
+ *
+ * @template {Element} T - Is an element or a node
+ * @param {!string} html
+ * @param {Element=} wrapper
+ * @return {T}
+ */
+function fixtureSync(html, wrapper) {
+  const tpl = template(html);
+  const parentNode = fixtureWrapper(wrapper);
+  parentNode.appendChild(document.importNode(tpl.content, true));
+  return parentNode.firstElementChild;
+}
+// # sourceMappingURL=fixture-no-side-effect.js.map

--- a/test/validation.html
+++ b/test/validation.html
@@ -416,7 +416,7 @@
           element.required = true;
           element.validate();
           expect(element.invalid).to.be.true;
-          element.value = 'value';
+          element.value = 'email@example.com';
           element.validate();
           expect(element.invalid).to.be.true;
         });
@@ -433,7 +433,7 @@
           element.required = true;
           element.validate();
           expect(element.invalid).to.be.true;
-          element.value = 'value';
+          element.value = 5;
           element.validate();
           expect(element.invalid).to.be.true;
         });
@@ -467,7 +467,7 @@
           element.required = true;
           element.validate();
           expect(element.invalid).to.be.true;
-          element.value = 'value';
+          element.value = 5;
           element.validate();
           expect(element.invalid).to.be.true;
         });

--- a/test/validation.html
+++ b/test/validation.html
@@ -216,6 +216,27 @@
             expect(tf.invalid).to.be.false;
           });
 
+          it('should fire a validated event on validation success', () => {
+            const validatedSpy = sinon.spy();
+            tf.addEventListener('validated', validatedSpy);
+            tf.validate();
+
+            expect(validatedSpy.calledOnce).to.be.true;
+            const event = validatedSpy.firstCall.args[0];
+            expect(event.detail.valid).to.be.true;
+          });
+
+          it('should fire a validated event on validation failure', () => {
+            const validatedSpy = sinon.spy();
+            tf.addEventListener('validated', validatedSpy);
+            tf.required = true;
+            tf.validate();
+
+            expect(validatedSpy.calledOnce).to.be.true;
+            const event = validatedSpy.firstCall.args[0];
+            expect(event.detail.valid).to.be.false;
+          });
+
           describe(`prevent invalid input ${condition}`, function() {
 
             beforeEach(function() {

--- a/test/validation.html
+++ b/test/validation.html
@@ -12,7 +12,9 @@
   <link rel="import" href="../vaadin-password-field.html">
   <link rel="import" href="../vaadin-text-area.html">
   <link rel="import" href="../vaadin-text-field.html">
+  <link rel="import" href="../vaadin-integer-field.html">
   <link rel="import" href="../../iron-form/iron-form.html">
+  <script src="invalid-common.js"></script>
 
 </head>
 
@@ -356,6 +358,119 @@
           });
         });
 
+      });
+    });
+
+    describe('invalid cannot be set to false', () => {
+      let element;
+
+      function nextRender(element) {
+        return new Promise(resolve => {
+          Polymer.RenderStatus.afterNextRender(element, resolve);
+        });
+      }
+
+      describe('text-field invalid', () => {
+        beforeEach(async() => {
+          element = fixtureSync('<vaadin-text-field></vaadin-text-field>');
+          element._shouldSetInvalid = (invalid) => invalid;
+          await nextRender();
+        });
+
+
+        it('should set invalid only when it is true', async() => {
+          element.required = true;
+          element.validate();
+          expect(element.invalid).to.be.true;
+          element.value = 'value';
+          element.validate();
+          expect(element.invalid).to.be.true;
+        });
+      });
+
+      describe('text-area invalid', () => {
+        beforeEach(async() => {
+          element = fixtureSync('<vaadin-text-area></vaadin-text-area>');
+          element._shouldSetInvalid = (invalid) => invalid;
+          await nextRender();
+        });
+
+        it('should set invalid only when it is true', async() => {
+          element.required = true;
+          element.validate();
+          expect(element.invalid).to.be.true;
+          element.value = 'value';
+          element.validate();
+          expect(element.invalid).to.be.true;
+        });
+      });
+
+      describe('email-field invalid', () => {
+        beforeEach(async() => {
+          element = fixtureSync('<vaadin-email-field></vaadin-email-field>');
+          element._shouldSetInvalid = (invalid) => invalid;
+          await nextRender();
+        });
+
+        it('should set invalid only when it is true', async() => {
+          element.required = true;
+          element.validate();
+          expect(element.invalid).to.be.true;
+          element.value = 'value';
+          element.validate();
+          expect(element.invalid).to.be.true;
+        });
+      });
+
+      describe('number-field invalid', () => {
+        beforeEach(async() => {
+          element = fixtureSync('<vaadin-number-field></vaadin-number-field>');
+          element._shouldSetInvalid = (invalid) => invalid;
+          await nextRender();
+        });
+
+        it('should set invalid only when it is true', async() => {
+          element.required = true;
+          element.validate();
+          expect(element.invalid).to.be.true;
+          element.value = 'value';
+          element.validate();
+          expect(element.invalid).to.be.true;
+        });
+      });
+
+      describe('password-field invalid', () => {
+        beforeEach(async() => {
+          element = fixtureSync('<vaadin-password-field></vaadin-password-field>');
+          element._shouldSetInvalid = (invalid) => invalid;
+          await nextRender();
+        });
+
+        it('should set invalid only when it is true', async() => {
+          element.required = true;
+          element.validate();
+          expect(element.invalid).to.be.true;
+          element.value = 'value';
+          element.validate();
+          expect(element.invalid).to.be.true;
+        });
+      });
+
+      describe('integer-field invalid', () => {
+        beforeEach(async() => {
+          element = fixtureSync('<vaadin-integer-field></vaadin-integer-field>');
+          element._shouldSetInvalid = (invalid) => invalid;
+          await nextRender();
+        });
+
+        it('should set invalid only when it is true', async() => {
+          element.required = true;
+          element.validate();
+          expect(element.invalid).to.be.true;
+          element.value = 'value';
+          element.validate();
+          expect(element.invalid).to.be.true;
+        });
       });
     });
   </script>


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

1. Fires a validated event when the web component's validation takes place. 
2. Adds a protected shouldSetInvalid() method. It will be used for preventing the web component from modifying the client-side invalid state on the Flow side afterward."

Fixes # (issue)

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
