### PR TITLE
revert: "fix: prevent initial validation when the field is initialized as invalid"

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -498,7 +498,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this.value = this.inputElement.value = '';
       }
 
-      if (this.invalid && oldVal !== undefined) {
+      if (this.invalid) {
         this.validate();
       }
     }

--- a/test/email-field-validation.html
+++ b/test/email-field-validation.html
@@ -18,39 +18,6 @@
     </template>
   </test-fixture>
 <script>
-  describe(`initial validation`, () => {
-    let field, validateSpy;
-
-    beforeEach(() => {
-      field = document.createElement('vaadin-email-field');
-      validateSpy = sinon.spy(field, 'validate');
-    });
-
-    afterEach(() => {
-      field.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      field.value = 'foo@example.com';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      field.value = 'foo@example.com';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   describe('basic', () => {
     let emailField;
 

--- a/test/integer-field-validation.html
+++ b/test/integer-field-validation.html
@@ -18,39 +18,6 @@
     </template>
   </test-fixture>
 <script>
-  describe(`initial validation`, () => {
-    let field, validateSpy;
-
-    beforeEach(() => {
-      field = document.createElement('vaadin-integer-field');
-      validateSpy = sinon.spy(field, 'validate');
-    });
-
-    afterEach(() => {
-      field.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      field.value = '2';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      field.value = '2';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   describe('basic', () => {
     let integerField;
 

--- a/test/number-field-validation.html
+++ b/test/number-field-validation.html
@@ -18,39 +18,6 @@
     </template>
   </test-fixture>
 <script>
-  describe(`initial validation`, () => {
-    let field, validateSpy;
-
-    beforeEach(() => {
-      field = document.createElement('vaadin-number-field');
-      validateSpy = sinon.spy(field, 'validate');
-    });
-
-    afterEach(() => {
-      field.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      field.value = '2';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      field.value = '2';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   describe('basic', () => {
     let numberField;
 

--- a/test/password-field-validation.html
+++ b/test/password-field-validation.html
@@ -18,39 +18,6 @@
     </template>
   </test-fixture>
 <script>
-  describe(`initial validation`, () => {
-    let field, validateSpy;
-
-    beforeEach(() => {
-      field = document.createElement('vaadin-password-field');
-      validateSpy = sinon.spy(field, 'validate');
-    });
-
-    afterEach(() => {
-      field.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      field.value = 'Initial Value';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      field.value = 'Initial Value';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   describe('basic', () => {
     let passwordField;
 

--- a/test/text-area-validation.html
+++ b/test/text-area-validation.html
@@ -18,39 +18,6 @@
     </template>
   </test-fixture>
 <script>
-  describe(`initial validation`, () => {
-    let field, validateSpy;
-
-    beforeEach(() => {
-      field = document.createElement('vaadin-text-area');
-      validateSpy = sinon.spy(field, 'validate');
-    });
-
-    afterEach(() => {
-      field.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      field.value = 'Initial Value';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      field.value = 'Initial Value';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   describe('basic', () => {
     let textArea;
 

--- a/test/text-field-validation.html
+++ b/test/text-field-validation.html
@@ -18,39 +18,6 @@
     </template>
   </test-fixture>
 <script>
-  describe(`initial validation`, () => {
-    let field, validateSpy;
-
-    beforeEach(() => {
-      field = document.createElement('vaadin-text-field');
-      validateSpy = sinon.spy(field, 'validate');
-    });
-
-    afterEach(() => {
-      field.remove();
-    });
-
-    it('should not validate by default', async() => {
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value', async() => {
-      field.value = 'Initial Value';
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-
-    it('should not validate when the field has an initial value and invalid', async() => {
-      field.value = 'Initial Value';
-      field.invalid = true;
-      document.body.appendChild(field);
-      await nextRender();
-      expect(validateSpy.called).to.be.false;
-    });
-  });
   describe('basic', () => {
     let textField;
 


### PR DESCRIPTION
Reverted https://github.com/vaadin/vaadin-text-field/pull/613. It was decided not to backport the PRs preventing initial validation as it is a breaking change.
 

Part of https://github.com/vaadin/web-components/issues/5763