### PR TITLE
fix: reset _hasInputValue on programmatic value clear (CP: 14)

### DIFF
--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -297,7 +297,11 @@ This program is available under Apache License Version 2.0, available at https:/
         },
 
         /**
-         * When true, the input element has a non-empty value entered by the user.
+         * Whether the input element has user input.
+         *
+         * Note, the property indicates true only if the input has been entered by the user.
+         * In the case of programmatic changes, the property must be reset to false.
+         *
          * @protected
          */
         _hasInputValue: {
@@ -824,6 +828,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     clear() {
+      this._hasInputValue = false;
       this.value = '';
     }
 

--- a/src/vaadin-text-field-mixin.html
+++ b/src/vaadin-text-field-mixin.html
@@ -297,10 +297,7 @@ This program is available under Apache License Version 2.0, available at https:/
         },
 
         /**
-         * Whether the input element has user input.
-         *
-         * Note, the property indicates true only if the input has been entered by the user.
-         * In the case of programmatic changes, the property must be reset to false.
+         * Whether the input element has a non-empty value.
          *
          * @protected
          */

--- a/test/email-field-events.html
+++ b/test/email-field-events.html
@@ -8,7 +8,6 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-email-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -29,7 +28,6 @@
           valueChangedSpy = sinon.spy();
           emailField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
           emailField.addEventListener('value-changed', valueChangedSpy);
-          await nextRender();
         });
 
         describe('without user input', () => {

--- a/test/email-field-events.html
+++ b/test/email-field-events.html
@@ -8,6 +8,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-email-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -18,37 +19,59 @@
   </test-fixture>
   <script>
     describe('events', () => {
-      let emailField, input;
+      let emailField, input, hasInputValueChangedSpy, valueChangedSpy;
     
       describe('has-input-value-changed event', () => {
         beforeEach(async() => {
           emailField = fixture('email-field');
           input = emailField.inputElement;
-        });
-    
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
           emailField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-    
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          emailField.addEventListener('value-changed', valueChangedSpy);
+          await nextRender();
         });
-    
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          emailField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          hasInputValueChangedSpy.reset();
-    
-          input.value = 'foobar';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+
+        describe('without user input', () => {
+          it('should fire the event once when entering input', async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+
+          it('should not fire the event on programmatic clear', async() => {
+            emailField.clear();
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+        });
+
+        describe('with user input', () => {
+          beforeEach(async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            hasInputValueChangedSpy.reset();
+            valueChangedSpy.reset();
+          });
+
+          it('should not fire the event when modifying input', async() => {
+            input.value = 'foobar';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+
+          it('should fire the event once when removing input', async() => {
+            input.value = '';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+
+          it('should fire the event once on programmatic clear', async() => {
+            emailField.clear();
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
     });

--- a/test/integer-field-events.html
+++ b/test/integer-field-events.html
@@ -8,6 +8,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-integer-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -18,37 +19,59 @@
   </test-fixture>
   <script>
     describe('events', () => {
-      let integerField, input;
+      let integerField, input, hasInputValueChangedSpy, valueChangedSpy;
     
       describe('has-input-value-changed event', () => {
         beforeEach(async() => {
           integerField = fixture('integer-field');
           input = integerField.inputElement;
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
+          integerField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+          integerField.addEventListener('value-changed', valueChangedSpy);
+          await nextRender();
         });
     
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          integerField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = '5';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        describe('without user input', () => {
+          it('should fire the event once when entering input', async() => {
+            input.value = '5';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
     
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          it('should not fire the event on programmatic clear', async() => {
+            integerField.clear();
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
         });
     
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          integerField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = '5';
-          input.dispatchEvent(new CustomEvent('input'));
-          hasInputValueChangedSpy.reset();
+        describe('with user input', () => {
+          beforeEach(async() => {
+            input.value = '5';
+            input.dispatchEvent(new CustomEvent('input'));
+            hasInputValueChangedSpy.reset();
+            valueChangedSpy.reset();
+          });
     
-          input.value = '56';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+          it('should not fire the event when modifying input', async() => {
+            input.value = '56';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+    
+          it('should fire the event once when removing input', async() => {
+            input.value = '';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+    
+          it('should fire the event once on programmatic clear', async() => {
+            integerField.clear();
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
     });

--- a/test/integer-field-events.html
+++ b/test/integer-field-events.html
@@ -8,7 +8,6 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-integer-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -29,7 +28,6 @@
           valueChangedSpy = sinon.spy();
           integerField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
           integerField.addEventListener('value-changed', valueChangedSpy);
-          await nextRender();
         });
     
         describe('without user input', () => {

--- a/test/number-field-events.html
+++ b/test/number-field-events.html
@@ -8,7 +8,6 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-number-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -29,7 +28,6 @@
           valueChangedSpy = sinon.spy();
           numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
           numberField.addEventListener('value-changed', valueChangedSpy);
-          await nextRender();
         });
     
         describe('without user input', () => {

--- a/test/number-field-events.html
+++ b/test/number-field-events.html
@@ -8,6 +8,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-number-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -18,37 +19,59 @@
   </test-fixture>
   <script>
     describe('events', () => {
-      let numberField, input;
+      let numberField, input, hasInputValueChangedSpy, valueChangedSpy;
     
       describe('has-input-value-changed event', () => {
         beforeEach(async() => {
           numberField = fixture('number-field');
           input = numberField.inputElement;
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
+          numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+          numberField.addEventListener('value-changed', valueChangedSpy);
+          await nextRender();
         });
     
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = '5';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        describe('without user input', () => {
+          it('should fire the event once when entering input', async() => {
+            input.value = '5';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
     
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          it('should not fire the event on programmatic clear', async() => {
+            numberField.clear();
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
         });
     
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          numberField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = '5';
-          input.dispatchEvent(new CustomEvent('input'));
-          hasInputValueChangedSpy.reset();
+        describe('with user input', () => {
+          beforeEach(async() => {
+            input.value = '5';
+            input.dispatchEvent(new CustomEvent('input'));
+            hasInputValueChangedSpy.reset();
+            valueChangedSpy.reset();
+          });
     
-          input.value = '56';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+          it('should not fire the event when modifying input', async() => {
+            input.value = '56';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+    
+          it('should fire the event once when removing input', async() => {
+            input.value = '';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+    
+          it('should fire the event once on programmatic clear', async() => {
+            numberField.clear();
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
     });

--- a/test/password-field-events.html
+++ b/test/password-field-events.html
@@ -8,6 +8,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-password-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -18,37 +19,59 @@
   </test-fixture>
   <script>
     describe('events', () => {
-      let passwordField, input;
+      let passwordField, input, hasInputValueChangedSpy, valueChangedSpy;
     
       describe('has-input-value-changed event', () => {
         beforeEach(async() => {
           passwordField = fixture('password-field');
           input = passwordField.inputElement;
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
+          passwordField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+          passwordField.addEventListener('value-changed', valueChangedSpy);
+          await nextRender();
         });
     
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          passwordField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        describe('without user input', () => {
+          it('should fire the event once when entering input', async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
     
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          it('should not fire the event on programmatic clear', async() => {
+            passwordField.clear();
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
         });
     
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          passwordField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          hasInputValueChangedSpy.reset();
+        describe('with user input', () => {
+          beforeEach(async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            hasInputValueChangedSpy.reset();
+            valueChangedSpy.reset();
+          });
     
-          input.value = 'foobar';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+          it('should not fire the event when modifying input', async() => {
+            input.value = 'foobar';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+    
+          it('should fire the event once when removing input', async() => {
+            input.value = '';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+    
+          it('should fire the event once on programmatic clear', async() => {
+            passwordField.clear();
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
     });

--- a/test/password-field-events.html
+++ b/test/password-field-events.html
@@ -8,7 +8,6 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-password-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -29,7 +28,6 @@
           valueChangedSpy = sinon.spy();
           passwordField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
           passwordField.addEventListener('value-changed', valueChangedSpy);
-          await nextRender();
         });
     
         describe('without user input', () => {

--- a/test/text-area-events.html
+++ b/test/text-area-events.html
@@ -8,6 +8,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-text-area.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -18,37 +19,59 @@
   </test-fixture>
   <script>
     describe('events', () => {
-      let textArea, input;
+      let textArea, input, hasInputValueChangedSpy, valueChangedSpy;
     
       describe('has-input-value-changed event', () => {
         beforeEach(async() => {
           textArea = fixture('text-area');
           input = textArea.inputElement;
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
+          textArea.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
+          textArea.addEventListener('value-changed', valueChangedSpy);
+          await nextRender();
         });
     
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          textArea.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+        describe('without user input', () => {
+          it('should fire the event once when entering input', async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
     
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          it('should not fire the event on programmatic clear', async() => {
+            textArea.clear();
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
         });
     
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          textArea.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          hasInputValueChangedSpy.reset();
+        describe('with user input', () => {
+          beforeEach(async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            hasInputValueChangedSpy.reset();
+            valueChangedSpy.reset();
+          });
     
-          input.value = 'foobar';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+          it('should not fire the event when modifying input', async() => {
+            input.value = 'foobar';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+    
+          it('should fire the event once when removing input', async() => {
+            input.value = '';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+    
+          it('should fire the event once on programmatic clear', async() => {
+            textArea.clear();
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
     });

--- a/test/text-area-events.html
+++ b/test/text-area-events.html
@@ -8,7 +8,6 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-text-area.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -29,7 +28,6 @@
           valueChangedSpy = sinon.spy();
           textArea.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
           textArea.addEventListener('value-changed', valueChangedSpy);
-          await nextRender();
         });
     
         describe('without user input', () => {

--- a/test/text-field-events.html
+++ b/test/text-field-events.html
@@ -8,7 +8,6 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-text-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -29,7 +28,6 @@
           valueChangedSpy = sinon.spy();
           textField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
           textField.addEventListener('value-changed', valueChangedSpy);
-          await nextRender();
         });
 
         describe('without user input', () => {

--- a/test/text-field-events.html
+++ b/test/text-field-events.html
@@ -8,6 +8,7 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../vaadin-text-field.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="helpers.html">
 </head>
 
 <body>
@@ -18,37 +19,59 @@
   </test-fixture>
   <script>
     describe('events', () => {
-      let textField, input;
+      let textField, input, hasInputValueChangedSpy, valueChangedSpy;
     
       describe('has-input-value-changed event', () => {
         beforeEach(async() => {
           textField = fixture('text-field');
           input = textField.inputElement;
-        });
-    
-        it('should fire the event on input value presence change', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
+          hasInputValueChangedSpy = sinon.spy();
+          valueChangedSpy = sinon.spy();
           textField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
-    
-          hasInputValueChangedSpy.reset();
-          input.value = '';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+          textField.addEventListener('value-changed', valueChangedSpy);
+          await nextRender();
         });
-    
-        it('should not fire the event on input if input value presence has not changed', async() => {
-          const hasInputValueChangedSpy = sinon.spy();
-          textField.addEventListener('has-input-value-changed', hasInputValueChangedSpy);
-          input.value = 'foo';
-          input.dispatchEvent(new CustomEvent('input'));
-          hasInputValueChangedSpy.reset();
-    
-          input.value = 'foobar';
-          input.dispatchEvent(new CustomEvent('input'));
-          expect(hasInputValueChangedSpy.called).to.be.false;
+
+        describe('without user input', () => {
+          it('should fire the event once when entering input', async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+
+          it('should not fire the event on programmatic clear', async() => {
+            textField.clear();
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+        });
+
+        describe('with user input', () => {
+          beforeEach(async() => {
+            input.value = 'foo';
+            input.dispatchEvent(new CustomEvent('input'));
+            hasInputValueChangedSpy.reset();
+            valueChangedSpy.reset();
+          });
+
+          it('should not fire the event when modifying input', async() => {
+            input.value = 'foobar';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.called).to.be.false;
+          });
+
+          it('should fire the event once when removing input', async() => {
+            input.value = '';
+            input.dispatchEvent(new CustomEvent('input'));
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
+
+          it('should fire the event once on programmatic clear', async() => {
+            textField.clear();
+            expect(hasInputValueChangedSpy.calledOnce).to.be.true;
+            expect(hasInputValueChangedSpy.calledBefore(valueChangedSpy)).to.be.true;
+          });
         });
       });
     });


### PR DESCRIPTION
## Description

Backports the following PRs:

- https://github.com/vaadin/web-components/pull/5599

Part of https://github.com/vaadin/web-components/issues/5763